### PR TITLE
Add resilient translation storage, job monitoring, and notifications

### DIFF
--- a/frontend/admin/lib/api.ts
+++ b/frontend/admin/lib/api.ts
@@ -179,7 +179,7 @@ export async function getTranslation(translationId: string){
 export async function getTranslationChunks(translationId: string){
   const res = await fetch(`${cfg.apiBase}/translations/${encodeURIComponent(translationId)}/chunks`, { headers: { ...(await authHeader()) } });
   if (!res.ok) throw new Error(`get translation chunks ${res.status}`);
-  return res.json() as Promise<{ chunks: TranslationChunk[]; headHtml?: string; sourceLanguage?: string; targetLanguage?: string }>;
+  return res.json() as Promise<{ translationId?: string; chunks: TranslationChunk[]; headHtml?: string; sourceLanguage?: string; targetLanguage?: string; lastReviewedAt?: string }>;
 }
 
 export async function updateTranslationChunks(translationId: string, chunks: Array<{ id: string; reviewerHtml: string; }>){
@@ -189,7 +189,7 @@ export async function updateTranslationChunks(translationId: string, chunks: Arr
     body: JSON.stringify({ chunks })
   });
   if (!res.ok) throw new Error(`update translation chunks ${res.status}`);
-  return res.json() as Promise<{ chunks: TranslationChunk[] }>;
+  return res.json() as Promise<{ chunks: TranslationChunk[]; headHtml?: string; lastReviewedAt?: string }>;
 }
 
 export async function approveTranslation(translationId: string){
@@ -290,6 +290,11 @@ export async function deleteAgent(agentId: string){
 }
 
 // User Management API
+export type NotificationPreferences = {
+  translation: { started: boolean; completed: boolean; failed: boolean };
+  documentation: { started: boolean; completed: boolean; failed: boolean };
+};
+
 export type User = {
   userId: string;
   email: string;
@@ -299,6 +304,10 @@ export type User = {
   created: string;
   lastModified: string;
   displayStatus: string;
+  notifications?: {
+    email: string | null;
+    preferences: NotificationPreferences;
+  };
 };
 
 export async function getUsers(): Promise<{ users: User[] }> {
@@ -351,6 +360,16 @@ export async function deleteUser(userId: string): Promise<{ message: string }> {
     headers: { 'Content-Type': 'application/json', ...(await authHeader()) },
   });
   if (!res.ok) throw new Error(`DELETE /users/${userId} ${res.status}`);
+  return res.json();
+}
+
+export async function updateUserNotificationPreferences(userId: string, payload: { email?: string; preferences: NotificationPreferences }): Promise<{ userId: string; email: string | null; preferences: NotificationPreferences }> {
+  const res = await fetch(`${cfg.apiBase}/users/${encodeURIComponent(userId)}/notifications`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', ...(await authHeader()) },
+    body: JSON.stringify(payload)
+  });
+  if (!res.ok) throw new Error(`PUT /users/${userId}/notifications ${res.status}`);
   return res.json();
 }
 

--- a/frontend/admin/lib/api.ts
+++ b/frontend/admin/lib/api.ts
@@ -179,7 +179,7 @@ export async function getTranslation(translationId: string){
 export async function getTranslationChunks(translationId: string){
   const res = await fetch(`${cfg.apiBase}/translations/${encodeURIComponent(translationId)}/chunks`, { headers: { ...(await authHeader()) } });
   if (!res.ok) throw new Error(`get translation chunks ${res.status}`);
-  return res.json() as Promise<{ translationId?: string; chunks: TranslationChunk[]; headHtml?: string; sourceLanguage?: string; targetLanguage?: string; lastReviewedAt?: string }>;
+  return res.json() as Promise<{ translationId?: string; chunks: TranslationChunk[]; headHtml?: string; sourceLanguage?: string; targetLanguage?: string; lastReviewedAt?: string; reviewLocked?: boolean; message?: string }>;
 }
 
 export async function updateTranslationChunks(translationId: string, chunks: Array<{ id: string; reviewerHtml: string; }>){

--- a/sam/resources.yaml
+++ b/sam/resources.yaml
@@ -22,6 +22,10 @@ Parameters:
     Type: String
     Default: docs
     Description: S3 Vectors index name
+  SesSenderEmail:
+    Type: String
+    Default: notifications@example.com
+    Description: Verified SES email identity used for job notifications
 
 Globals:
   Function:
@@ -44,6 +48,7 @@ Globals:
         VECTOR_DIMENSION: '1536'
         TRANSLATION_PROVIDER: openai
         TRANSLATION_MODEL: gpt-4o-mini
+        SES_SENDER: !Ref SesSenderEmail
 
 Resources:
   Api:
@@ -259,6 +264,8 @@ Resources:
       Environment:
         Variables:
           ENABLE_TERM_STATS: 'true'
+          SETTINGS_TABLE: !ImportValue { 'Fn::Sub': '${ProjectName}-${Stage}-SettingsTableName' }
+          SES_SENDER: !Ref SesSenderEmail
       Policies:
         - Statement:
             - Effect: Allow
@@ -291,6 +298,12 @@ Resources:
                 - events:PutEvents
               Resource:
                 - "*"
+        - Statement:
+            - Effect: Allow
+              Action:
+                - ses:SendEmail
+                - ses:SendRawEmail
+              Resource: '*'
 
   S3PutRule:
     Type: AWS::Events::Rule
@@ -420,6 +433,8 @@ Resources:
           RAW_BUCKET: !ImportValue { 'Fn::Sub': '${ProjectName}-${Stage}-RawBucketName' }
           TRANSLATION_PROVIDER: openai
           TRANSLATION_MODEL: gpt-4o-mini
+          SETTINGS_TABLE: !ImportValue { 'Fn::Sub': '${ProjectName}-${Stage}-SettingsTableName' }
+          SES_SENDER: !Ref SesSenderEmail
       Policies:
         - Statement:
             - Effect: Allow
@@ -439,6 +454,12 @@ Resources:
             - Effect: Allow
               Action:
                 - events:PutEvents
+              Resource: '*'
+        - Statement:
+            - Effect: Allow
+              Action:
+                - ses:SendEmail
+                - ses:SendRawEmail
               Resource: '*'
       Events:
         PostTranslationUploadUrl:
@@ -516,6 +537,8 @@ Resources:
           RAW_BUCKET: !ImportValue { 'Fn::Sub': '${ProjectName}-${Stage}-RawBucketName' }
           TRANSLATION_PROVIDER: openai
           TRANSLATION_MODEL: gpt-4o-mini
+          SETTINGS_TABLE: !ImportValue { 'Fn::Sub': '${ProjectName}-${Stage}-SettingsTableName' }
+          SES_SENDER: !Ref SesSenderEmail
       Policies:
         - Statement:
             - Effect: Allow
@@ -537,6 +560,12 @@ Resources:
             BucketName: '*'
         - S3WritePolicy:
             BucketName: '*'
+        - Statement:
+            - Effect: Allow
+              Action:
+                - ses:SendEmail
+                - ses:SendRawEmail
+              Resource: '*'
 
   TranslationEventRule:
     Type: AWS::Events::Rule
@@ -556,6 +585,51 @@ Resources:
       FunctionName: !Ref TranslationWorkerFn
       Principal: events.amazonaws.com
       SourceArn: !GetAtt TranslationEventRule.Arn
+
+  JobHealthCheckFn:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub "${ProjectName}-${Stage}-job-health"
+      CodeUri: ../src
+      Handler: handlers/jobHealthCheck.handler
+      Timeout: 120
+      Environment:
+        Variables:
+          DOCS_TABLE: !ImportValue { 'Fn::Sub': '${ProjectName}-${Stage}-DocsTableName' }
+          RAW_BUCKET: !ImportValue { 'Fn::Sub': '${ProjectName}-${Stage}-RawBucketName' }
+          SETTINGS_TABLE: !ImportValue { 'Fn::Sub': '${ProjectName}-${Stage}-SettingsTableName' }
+          SES_SENDER: !Ref SesSenderEmail
+          INGEST_WORKER_FUNCTION_NAME: !Sub "${ProjectName}-${Stage}-ingest-worker"
+          JOB_HEALTH_STALE_MINUTES: '15'
+          JOB_HEALTH_MAX_RETRIES: '3'
+      Policies:
+        - Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:*
+              Resource: '*'
+        - Statement:
+            - Effect: Allow
+              Action:
+                - events:PutEvents
+              Resource: '*'
+        - Statement:
+            - Effect: Allow
+              Action:
+                - lambda:InvokeFunction
+              Resource: !GetAtt IngestionWorkerFn.Arn
+        - Statement:
+            - Effect: Allow
+              Action:
+                - ses:SendEmail
+                - ses:SendRawEmail
+              Resource: '*'
+      Events:
+        ScheduledCheck:
+          Type: Schedule
+          Properties:
+            Schedule: rate(10 minutes)
+            Name: !Sub "${ProjectName}-${Stage}-job-health"
 
   ViewDocFn:
     Type: AWS::Serverless::Function

--- a/src/handlers/helpers/jobMonitor.js
+++ b/src/handlers/helpers/jobMonitor.js
@@ -1,0 +1,159 @@
+const { DynamoDBClient, ScanCommand, UpdateItemCommand } = require('@aws-sdk/client-dynamodb');
+const { EventBridgeClient, PutEventsCommand } = require('@aws-sdk/client-eventbridge');
+const { LambdaClient, InvokeCommand } = require('@aws-sdk/client-lambda');
+const { marshall, unmarshall } = require('@aws-sdk/util-dynamodb');
+const { listChunks, summariseChunks } = require('./translationStore');
+const { sendJobNotification } = require('./notifications');
+
+const ddb = new DynamoDBClient({});
+const eb = new EventBridgeClient({});
+const lambda = new LambdaClient({});
+
+const DOCS_TABLE = process.env.DOCS_TABLE;
+const RAW_BUCKET = process.env.RAW_BUCKET;
+const INGEST_WORKER_FUNCTION = process.env.INGEST_WORKER_FUNCTION_NAME;
+
+function minutesAgo(minutes) {
+  return Date.now() - minutes * 60 * 1000;
+}
+
+function isoToMs(value) {
+  if (!value) return 0;
+  const ts = Date.parse(value);
+  return Number.isFinite(ts) ? ts : 0;
+}
+
+async function scanTranslations(status) {
+  if (!DOCS_TABLE) return [];
+  const res = await ddb.send(new ScanCommand({
+    TableName: DOCS_TABLE,
+    FilterExpression: 'begins_with(#pk, :pkPrefix) AND begins_with(#sk, :skPrefix) AND #status = :status',
+    ExpressionAttributeNames: {
+      '#pk': 'PK',
+      '#sk': 'SK',
+      '#status': 'status'
+    },
+    ExpressionAttributeValues: marshall({
+      ':pkPrefix': 'TRANSLATION#',
+      ':skPrefix': 'TRANSLATION#',
+      ':status': status
+    })
+  }));
+  return (res.Items || []).map(item => unmarshall(item));
+}
+
+async function scanDocs(status) {
+  if (!DOCS_TABLE) return [];
+  const res = await ddb.send(new ScanCommand({
+    TableName: DOCS_TABLE,
+    FilterExpression: 'begins_with(#pk, :pkPrefix) AND begins_with(#sk, :skPrefix) AND #status = :status',
+    ExpressionAttributeNames: {
+      '#pk': 'PK',
+      '#sk': 'SK',
+      '#status': 'status'
+    },
+    ExpressionAttributeValues: marshall({
+      ':pkPrefix': 'DOC#',
+      ':skPrefix': 'DOC#',
+      ':status': status
+    })
+  }));
+  return (res.Items || []).map(item => unmarshall(item));
+}
+
+async function evaluateTranslation(translation, { staleMinutes }) {
+  const ownerId = translation.ownerId || 'default';
+  const translationId = translation.translationId;
+  const chunks = await listChunks(translationId, ownerId);
+  const summary = summariseChunks(chunks);
+  const activityCandidates = [summary.latestUpdate, translation.updatedAt, translation.createdAt, translation.startedAt];
+  const latestMs = activityCandidates.map(isoToMs).reduce((acc, value) => (value > acc ? value : acc), 0);
+  const stale = latestMs && latestMs < minutesAgo(staleMinutes)
+    ? { reason: 'stale', lastActivity: new Date(latestMs).toISOString() }
+    : null;
+  const missingChunks = summary.total === 0;
+  const readyToComplete = summary.total > 0 && summary.total === summary.completed;
+  return {
+    translation,
+    ownerId,
+    translationId,
+    chunks,
+    summary,
+    stale,
+    missingChunks,
+    readyToComplete
+  };
+}
+
+async function evaluateDoc(doc, { staleMinutes }) {
+  const updatedAt = isoToMs(doc.updatedAt);
+  const stale = updatedAt && updatedAt < minutesAgo(staleMinutes)
+    ? { reason: 'stale', lastActivity: doc.updatedAt }
+    : null;
+  return {
+    doc,
+    stale
+  };
+}
+
+async function restartTranslation(translationId, ownerId) {
+  await eb.send(new PutEventsCommand({
+    Entries: [{
+      Source: 'ops-agent',
+      DetailType: 'TranslationRequested',
+      Detail: JSON.stringify({ translationId, ownerId })
+    }]
+  }));
+}
+
+async function invokeIngestWorker(doc) {
+  if (!INGEST_WORKER_FUNCTION || !RAW_BUCKET) return;
+  const key = doc.fileKey;
+  if (!key) return;
+  const payload = {
+    detail: {
+      bucket: { name: RAW_BUCKET },
+      object: { key }
+    }
+  };
+  await lambda.send(new InvokeCommand({
+    FunctionName: INGEST_WORKER_FUNCTION,
+    InvocationType: 'Event',
+    Payload: Buffer.from(JSON.stringify(payload))
+  }));
+}
+
+async function markTranslationFailed(translationId, ownerId, reason) {
+  if (!DOCS_TABLE) return;
+  const patch = {
+    '#status': 'status',
+    '#updatedAt': 'updatedAt',
+    '#errorMessage': 'errorMessage',
+    '#errorContext': 'errorContext'
+  };
+  const values = marshall({
+    ':status': 'FAILED',
+    ':updatedAt': new Date().toISOString(),
+    ':errorMessage': 'Translation stalled',
+    ':errorContext': reason || 'Stale job detected by health check'
+  });
+  await ddb.send(new UpdateItemCommand({
+    TableName: DOCS_TABLE,
+    Key: marshall({ PK: `TRANSLATION#${translationId}`, SK: `TRANSLATION#${ownerId}` }),
+    UpdateExpression: 'SET #status = :status, #updatedAt = :updatedAt, #errorMessage = :errorMessage, #errorContext = :errorContext',
+    ExpressionAttributeNames: patch,
+    ExpressionAttributeValues: values
+  }));
+}
+
+module.exports = {
+  scanTranslations,
+  scanDocs,
+  evaluateTranslation,
+  evaluateDoc,
+  restartTranslation,
+  invokeIngestWorker,
+  markTranslationFailed,
+  sendJobNotification
+};
+

--- a/src/handlers/helpers/notifications.js
+++ b/src/handlers/helpers/notifications.js
@@ -1,0 +1,135 @@
+const { SESClient, SendEmailCommand } = require('@aws-sdk/client-ses');
+const { DynamoDBClient, GetItemCommand, PutItemCommand, ScanCommand } = require('@aws-sdk/client-dynamodb');
+const { marshall, unmarshall } = require('@aws-sdk/util-dynamodb');
+
+const ses = new SESClient({});
+const ddb = new DynamoDBClient({});
+
+const SETTINGS_TABLE = process.env.SETTINGS_TABLE;
+const SES_SENDER = process.env.SES_SENDER || process.env.SES_FROM_ADDRESS || process.env.SES_FROM;
+
+function now() {
+  return new Date().toISOString();
+}
+
+function normalisePreferences(input = {}) {
+  const defaults = {
+    translation: { started: false, completed: true, failed: true },
+    documentation: { started: false, completed: true, failed: true }
+  };
+  const out = {};
+  for (const jobType of Object.keys(defaults)) {
+    const base = defaults[jobType];
+    const provided = input[jobType] || {};
+    out[jobType] = {
+      started: Boolean(provided.started ?? base.started),
+      completed: Boolean(provided.completed ?? base.completed),
+      failed: Boolean(provided.failed ?? base.failed)
+    };
+  }
+  return out;
+}
+
+async function getUserNotificationPreferences(userId) {
+  if (!SETTINGS_TABLE || !userId) return null;
+  const key = { PK: `USER#${userId}`, SK: 'NOTIFY#v1' };
+  const res = await ddb.send(new GetItemCommand({ TableName: SETTINGS_TABLE, Key: marshall(key) }));
+  if (!res.Item) return null;
+  const item = unmarshall(res.Item);
+  return {
+    userId,
+    email: item.email || null,
+    preferences: normalisePreferences(item.preferences || {}),
+    updatedAt: item.updatedAt || null
+  };
+}
+
+async function putUserNotificationPreferences({ userId, email, preferences }) {
+  if (!SETTINGS_TABLE || !userId) return null;
+  const item = {
+    PK: `USER#${userId}`,
+    SK: 'NOTIFY#v1',
+    userId,
+    email: email || null,
+    preferences: normalisePreferences(preferences || {}),
+    updatedAt: now()
+  };
+  await ddb.send(new PutItemCommand({ TableName: SETTINGS_TABLE, Item: marshall(item) }));
+  return item;
+}
+
+async function scanNotificationPreferences() {
+  if (!SETTINGS_TABLE) return [];
+  const res = await ddb.send(new ScanCommand({
+    TableName: SETTINGS_TABLE,
+    FilterExpression: 'begins_with(#pk, :pkPrefix) AND #sk = :sk',
+    ExpressionAttributeNames: {
+      '#pk': 'PK',
+      '#sk': 'SK'
+    },
+    ExpressionAttributeValues: marshall({
+      ':pkPrefix': 'USER#',
+      ':sk': 'NOTIFY#v1'
+    })
+  }));
+  return (res.Items || []).map(item => unmarshall(item));
+}
+
+async function recipientsFor(jobType, status) {
+  const items = await scanNotificationPreferences();
+  const out = [];
+  for (const item of items) {
+    const prefs = normalisePreferences(item.preferences || {});
+    if (prefs?.[jobType]?.[status] && item.email) {
+      out.push({ email: item.email, userId: item.userId || item.PK?.replace('USER#', '') || null });
+    }
+  }
+  return out;
+}
+
+function buildEmail({ jobType, status, fileName, jobId }) {
+  const subject = `[Ops Agent] ${jobType === 'documentation' ? 'Documentation ingestion' : 'Translation'} ${status}`;
+  const lines = [
+    `Job type: ${jobType === 'documentation' ? 'documentation' : 'translation'}`,
+    `Status: ${status}`,
+    fileName ? `File: ${fileName}` : null,
+    jobId ? `Job ID: ${jobId}` : null,
+    `Timestamp: ${now()}`
+  ].filter(Boolean);
+  return { subject, body: lines.join('\n') };
+}
+
+async function sendJobNotification({ jobType, status, fileName, jobId }) {
+  if (!SES_SENDER) {
+    console.warn('sendJobNotification skipped - SES_SENDER not configured');
+    return { sent: false, reason: 'no-sender' };
+  }
+  try {
+    const recipients = await recipientsFor(jobType, status);
+    if (!recipients.length) {
+      return { sent: false, reason: 'no-recipients' };
+    }
+    const { subject, body } = buildEmail({ jobType, status, fileName, jobId });
+    await ses.send(new SendEmailCommand({
+      Destination: { ToAddresses: recipients.map(r => r.email) },
+      Source: SES_SENDER,
+      Message: {
+        Subject: { Data: subject, Charset: 'UTF-8' },
+        Body: { Text: { Data: body, Charset: 'UTF-8' } }
+      }
+    }));
+    return { sent: true, recipients: recipients.length };
+  } catch (error) {
+    console.error('sendJobNotification failed', error);
+    return { sent: false, error: error.message };
+  }
+}
+
+module.exports = {
+  getUserNotificationPreferences,
+  putUserNotificationPreferences,
+  recipientsFor,
+  sendJobNotification,
+  normalisePreferences
+};
+

--- a/src/handlers/helpers/translationStore.js
+++ b/src/handlers/helpers/translationStore.js
@@ -1,0 +1,139 @@
+const { DynamoDBClient, QueryCommand, UpdateItemCommand, BatchWriteItemCommand } = require('@aws-sdk/client-dynamodb');
+const { marshall, unmarshall } = require('@aws-sdk/util-dynamodb');
+
+const ddb = new DynamoDBClient({});
+
+const DOCS_TABLE = process.env.DOCS_TABLE;
+
+if (!DOCS_TABLE) {
+  console.warn('translationStore initialised without DOCS_TABLE environment variable');
+}
+
+function now() {
+  return new Date().toISOString();
+}
+
+function chunkSortKey(order) {
+  const padded = String(Number(order || 0)).padStart(6, '0');
+  return `CHUNK#${padded}`;
+}
+
+function chunkPrimaryKey(translationId, ownerId, order) {
+  return {
+    PK: `TRANSLATION#${translationId}`,
+    SK: chunkSortKey(order)
+  };
+}
+
+async function listChunks(translationId, ownerId) {
+  if (!DOCS_TABLE) return [];
+  const params = {
+    TableName: DOCS_TABLE,
+    KeyConditionExpression: '#pk = :pk AND begins_with(#sk, :skPrefix)',
+    ExpressionAttributeNames: {
+      '#pk': 'PK',
+      '#sk': 'SK'
+    },
+    ExpressionAttributeValues: marshall({
+      ':pk': `TRANSLATION#${translationId}`,
+      ':skPrefix': 'CHUNK#'
+    })
+  };
+  const res = await ddb.send(new QueryCommand(params));
+  return (res.Items || []).map(item => unmarshall(item));
+}
+
+async function ensureChunkSource({ translationId, ownerId = 'default', chunk }) {
+  if (!DOCS_TABLE || !chunk) return;
+  const key = chunkPrimaryKey(translationId, ownerId, chunk.order);
+  const names = {
+    '#updatedAt': 'updatedAt',
+    '#chunkId': 'chunkId',
+    '#order': 'order',
+    '#status': 'status',
+    '#sourceHtml': 'sourceHtml',
+    '#sourceText': 'sourceText',
+    '#createdAt': 'createdAt'
+  };
+  const values = marshall({
+    ':updatedAt': now(),
+    ':chunkId': chunk.id,
+    ':order': chunk.order,
+    ':status': 'PENDING',
+    ':sourceHtml': chunk.sourceHtml || '',
+    ':sourceText': chunk.sourceText || '',
+    ':createdAt': now()
+  });
+  const res = await ddb.send(new UpdateItemCommand({
+    TableName: DOCS_TABLE,
+    Key: marshall(key),
+    UpdateExpression: 'SET #updatedAt = :updatedAt, #chunkId = :chunkId, #order = :order, #sourceHtml = :sourceHtml, #sourceText = :sourceText, #status = if_not_exists(#status, :status), #createdAt = if_not_exists(#createdAt, :createdAt)',
+    ExpressionAttributeNames: names,
+    ExpressionAttributeValues: values,
+    ReturnValues: 'ALL_NEW'
+  }));
+  return res.Attributes ? unmarshall(res.Attributes) : undefined;
+}
+
+async function updateChunkState({ translationId, ownerId = 'default', chunkOrder, patch }) {
+  if (!DOCS_TABLE || !patch || typeof chunkOrder === 'undefined') return;
+  const key = chunkPrimaryKey(translationId, ownerId, chunkOrder);
+  const names = { '#updatedAt': 'updatedAt' };
+  const sets = ['#updatedAt = :updatedAt'];
+  const values = { ':updatedAt': now() };
+  for (const [field, value] of Object.entries(patch)) {
+    names[`#${field}`] = field;
+    values[`:${field}`] = value;
+    sets.push(`#${field} = :${field}`);
+  }
+  const res = await ddb.send(new UpdateItemCommand({
+    TableName: DOCS_TABLE,
+    Key: marshall(key),
+    UpdateExpression: `SET ${sets.join(', ')}`,
+    ExpressionAttributeNames: names,
+    ExpressionAttributeValues: marshall(values),
+    ReturnValues: 'ALL_NEW'
+  }));
+  return res.Attributes ? unmarshall(res.Attributes) : undefined;
+}
+
+async function deleteAllChunks(translationId, ownerId = 'default') {
+  if (!DOCS_TABLE) return;
+  const chunks = await listChunks(translationId, ownerId);
+  if (!chunks.length) return;
+  const requests = chunks.map(chunk => ({
+    DeleteRequest: {
+      Key: marshall({ PK: chunk.PK, SK: chunk.SK })
+    }
+  }));
+  while (requests.length) {
+    const batch = requests.splice(0, 25);
+    await ddb.send(new BatchWriteItemCommand({
+      RequestItems: {
+        [DOCS_TABLE]: batch
+      }
+    }));
+  }
+}
+
+function summariseChunks(chunks = []) {
+  const total = chunks.length;
+  const completed = chunks.filter(chunk => chunk.status === 'COMPLETED').length;
+  const failed = chunks.filter(chunk => chunk.status === 'FAILED').length;
+  const latestUpdate = chunks.reduce((acc, chunk) => {
+    const ts = chunk.updatedAt || chunk.lastUpdatedAt || chunk.completedAt;
+    if (!ts) return acc;
+    return !acc || new Date(ts) > new Date(acc) ? ts : acc;
+  }, null);
+  return { total, completed, failed, latestUpdate };
+}
+
+module.exports = {
+  listChunks,
+  ensureChunkSource,
+  updateChunkState,
+  deleteAllChunks,
+  summariseChunks,
+  chunkSortKey
+};
+

--- a/src/handlers/jobHealthCheck.js
+++ b/src/handlers/jobHealthCheck.js
@@ -1,0 +1,147 @@
+const { DynamoDBClient, UpdateItemCommand } = require('@aws-sdk/client-dynamodb');
+const { marshall, unmarshall } = require('@aws-sdk/util-dynamodb');
+const {
+  scanTranslations,
+  evaluateTranslation,
+  restartTranslation,
+  markTranslationFailed,
+  scanDocs,
+  evaluateDoc,
+  invokeIngestWorker,
+  sendJobNotification
+} = require('./helpers/jobMonitor');
+
+const ddb = new DynamoDBClient({});
+
+const DOCS_TABLE = process.env.DOCS_TABLE;
+const STALE_MINUTES = Number(process.env.JOB_HEALTH_STALE_MINUTES || 15);
+const RETRY_LIMIT = Number(process.env.JOB_HEALTH_MAX_RETRIES || 3);
+
+function now() {
+  return new Date().toISOString();
+}
+
+async function incrementTranslationRetry(translationId, ownerId, reason) {
+  if (!DOCS_TABLE) return 0;
+  const res = await ddb.send(new UpdateItemCommand({
+    TableName: DOCS_TABLE,
+    Key: marshall({ PK: `TRANSLATION#${translationId}`, SK: `TRANSLATION#${ownerId}` }),
+    UpdateExpression: 'SET #retries = if_not_exists(#retries, :zero) + :one, #healthReason = :reason, #healthCheckedAt = :now',
+    ExpressionAttributeNames: {
+      '#retries': 'healthCheckRetries',
+      '#healthReason': 'healthCheckReason',
+      '#healthCheckedAt': 'healthCheckedAt'
+    },
+    ExpressionAttributeValues: marshall({
+      ':zero': 0,
+      ':one': 1,
+      ':reason': reason,
+      ':now': now()
+    }),
+    ReturnValues: 'ALL_NEW'
+  }));
+  const attrs = res.Attributes ? unmarshall(res.Attributes) : {};
+  return attrs.healthCheckRetries || 0;
+}
+
+async function incrementDocRetry(docId, agentId, reason) {
+  if (!DOCS_TABLE) return 0;
+  const res = await ddb.send(new UpdateItemCommand({
+    TableName: DOCS_TABLE,
+    Key: marshall({ PK: `DOC#${docId}`, SK: `DOC#${agentId}` }),
+    UpdateExpression: 'SET #retries = if_not_exists(#retries, :zero) + :one, #healthReason = :reason, #healthCheckedAt = :now',
+    ExpressionAttributeNames: {
+      '#retries': 'healthCheckRetries',
+      '#healthReason': 'healthCheckReason',
+      '#healthCheckedAt': 'healthCheckedAt'
+    },
+    ExpressionAttributeValues: marshall({
+      ':zero': 0,
+      ':one': 1,
+      ':reason': reason,
+      ':now': now()
+    }),
+    ReturnValues: 'ALL_NEW'
+  }));
+  const attrs = res.Attributes ? unmarshall(res.Attributes) : {};
+  return attrs.healthCheckRetries || 0;
+}
+
+async function markDocFailed(doc, reason) {
+  if (!DOCS_TABLE) return;
+  await ddb.send(new UpdateItemCommand({
+    TableName: DOCS_TABLE,
+    Key: marshall({ PK: `DOC#${doc.docId}`, SK: `DOC#${doc.agentId}` }),
+    UpdateExpression: 'SET #status = :status, #updatedAt = :updatedAt, #error = :error',
+    ExpressionAttributeNames: {
+      '#status': 'status',
+      '#updatedAt': 'updatedAt',
+      '#error': 'error'
+    },
+    ExpressionAttributeValues: marshall({
+      ':status': 'FAILED',
+      ':updatedAt': now(),
+      ':error': reason || 'Processing stalled'
+    })
+  }));
+  await sendJobNotification({
+    jobType: 'documentation',
+    status: 'failed',
+    fileName: doc.title || doc.fileKey?.split('/').pop() || doc.docId,
+    jobId: doc.docId
+  });
+}
+
+exports.handler = async () => {
+  const result = {
+    translationsChecked: 0,
+    translationsRestarted: 0,
+    translationsFailed: 0,
+    docsChecked: 0,
+    docsRestarted: 0,
+    docsFailed: 0
+  };
+
+  const translations = await scanTranslations('PROCESSING');
+  result.translationsChecked = translations.length;
+  for (const translation of translations) {
+    const report = await evaluateTranslation(translation, { staleMinutes: STALE_MINUTES });
+    if (!report.missingChunks && !report.stale) {
+      continue;
+    }
+    const reason = report.missingChunks ? 'no-chunks' : 'stale-progress';
+    const retries = await incrementTranslationRetry(report.translationId, report.ownerId, reason);
+    if (retries > RETRY_LIMIT) {
+      await markTranslationFailed(report.translationId, report.ownerId, reason);
+      await sendJobNotification({
+        jobType: 'translation',
+        status: 'failed',
+        fileName: translation.originalFilename || translation.title || translation.translationId,
+        jobId: report.translationId
+      });
+      result.translationsFailed += 1;
+      continue;
+    }
+    await restartTranslation(report.translationId, report.ownerId);
+    result.translationsRestarted += 1;
+  }
+
+  const docs = await scanDocs('PROCESSING');
+  result.docsChecked = docs.length;
+  for (const doc of docs) {
+    const report = await evaluateDoc(doc, { staleMinutes: STALE_MINUTES });
+    if (!report.stale) continue;
+    const retries = await incrementDocRetry(doc.docId, doc.agentId || 'default', 'stale');
+    if (retries > RETRY_LIMIT) {
+      await markDocFailed(doc, 'Stale ingestion detected by health check');
+      result.docsFailed += 1;
+      continue;
+    }
+    await invokeIngestWorker(doc);
+    result.docsRestarted += 1;
+  }
+
+  console.log('jobHealthCheck summary', result);
+  return result;
+};
+

--- a/src/handlers/translations.js
+++ b/src/handlers/translations.js
@@ -7,6 +7,8 @@ const HtmlDocx = require('html-docx-js');
 const crypto = require('node:crypto');
 const { response } = require('./helpers/utils');
 const { assembleHtmlDocument } = require('./helpers/documentParser');
+const { listChunks, updateChunkState, deleteAllChunks, summariseChunks } = require('./helpers/translationStore');
+const { sendJobNotification } = require('./helpers/notifications');
 
 const ddb = new DynamoDBClient({});
 const s3 = new S3Client({});
@@ -157,6 +159,13 @@ async function createTranslation(body, eventOwner, requester) {
     }]
   }));
 
+  await sendJobNotification({
+    jobType: 'translation',
+    status: 'started',
+    fileName: filename,
+    jobId: translationId
+  });
+
   return item;
 }
 
@@ -205,16 +214,6 @@ async function updateTranslation(translationId, ownerId, patch) {
   }));
 }
 
-async function loadChunks(chunkKey) {
-  const res = await s3.send(new GetObjectCommand({ Bucket: RAW_BUCKET, Key: chunkKey }));
-  const bytes = await res.Body.transformToByteArray();
-  return JSON.parse(Buffer.from(bytes).toString('utf8'));
-}
-
-async function saveChunks(chunkKey, payload) {
-  await s3.send(new PutObjectCommand({ Bucket: RAW_BUCKET, Key: chunkKey, Body: JSON.stringify(payload), ContentType: 'application/json' }));
-}
-
 async function objectExists(key) {
   try {
     await s3.send(new HeadObjectCommand({ Bucket: RAW_BUCKET, Key: key }));
@@ -228,6 +227,50 @@ async function objectExists(key) {
   }
 }
 
+function normaliseChunkRecord(record) {
+  return {
+    id: record.chunkId,
+    order: record.order,
+    sourceHtml: record.sourceHtml,
+    sourceText: record.sourceText,
+    machineHtml: record.machineHtml,
+    reviewerHtml: record.reviewerHtml || null,
+    lastUpdatedBy: record.lastUpdatedBy || null,
+    lastUpdatedAt: record.lastUpdatedAt || record.updatedAt || null,
+    reviewerName: record.reviewerName || null
+  };
+}
+
+async function fetchChunkState(item, ownerId) {
+  const records = await listChunks(item.translationId, ownerId);
+  if (!records.length) return null;
+  const sorted = records.sort((a, b) => (a.order || 0) - (b.order || 0));
+  return sorted.map(normaliseChunkRecord);
+}
+
+function buildChunkPayload(item, chunks) {
+  return {
+    translationId: item.translationId,
+    generatedAt: now(),
+    sourceLanguage: item.sourceLanguage,
+    targetLanguage: item.targetLanguage,
+    provider: item.provider || null,
+    model: item.model || null,
+    headHtml: item.headHtml || '<head><meta charset="utf-8"/></head>',
+    chunks
+  };
+}
+
+async function persistChunkPayload(item, ownerId, chunks) {
+  if (!RAW_BUCKET) return;
+  const payload = buildChunkPayload(item, chunks);
+  const key = item.chunkFileKey || `translations/chunks/${ownerId}/${item.translationId}.json`;
+  await s3.send(new PutObjectCommand({ Bucket: RAW_BUCKET, Key: key, Body: JSON.stringify(payload), ContentType: 'application/json' }));
+  if (!item.chunkFileKey) {
+    await updateTranslation(item.translationId, ownerId, { chunkFileKey: key });
+  }
+}
+
 async function handleChunkUpdate(event, translationId, ownerId, reviewer) {
   const body = parseBody(event);
   if (!body.chunks || !Array.isArray(body.chunks)) {
@@ -235,43 +278,72 @@ async function handleChunkUpdate(event, translationId, ownerId, reviewer) {
   }
 
   const item = await getTranslation(translationId, ownerId);
-  if (!item?.chunkFileKey) {
-    throw new Error('No chunk file found for translation');
+  const records = await listChunks(translationId, ownerId);
+  if (!records.length) {
+    throw new Error('No chunk data found for translation');
   }
-  const chunkData = await loadChunks(item.chunkFileKey);
-  const chunkMap = new Map((chunkData.chunks || []).map(chunk => [chunk.id, chunk]));
+  const chunkMap = new Map(records.map(record => [record.chunkId, record]));
   const updatedAt = now();
   for (const incoming of body.chunks) {
-    const target = chunkMap.get(incoming.id);
-    if (!target) continue;
-    let nextHtml = target.machineHtml;
+    const record = chunkMap.get(incoming.id);
+    if (!record) continue;
+    let nextHtml = record.machineHtml;
     if (Object.prototype.hasOwnProperty.call(incoming, 'reviewerHtml')) {
-      nextHtml = typeof incoming.reviewerHtml === 'string' ? incoming.reviewerHtml : target.machineHtml;
+      nextHtml = typeof incoming.reviewerHtml === 'string' ? incoming.reviewerHtml : record.machineHtml;
     } else if (Object.prototype.hasOwnProperty.call(incoming, 'html')) {
-      nextHtml = typeof incoming.html === 'string' ? incoming.html : target.machineHtml;
+      nextHtml = typeof incoming.html === 'string' ? incoming.html : record.machineHtml;
     } else if (Object.prototype.hasOwnProperty.call(incoming, 'text')) {
-      nextHtml = typeof incoming.text === 'string' ? incoming.text : target.machineHtml;
+      nextHtml = typeof incoming.text === 'string' ? incoming.text : record.machineHtml;
     }
-    target.reviewerHtml = nextHtml;
-    target.lastUpdatedBy = reviewer.email || reviewer.name || reviewer.sub || 'reviewer';
-    target.lastUpdatedAt = updatedAt;
-    target.reviewerName = reviewer.name || target.reviewerName || null;
+    const updated = await updateChunkState({
+      translationId,
+      ownerId,
+      chunkOrder: record.order,
+      patch: {
+        reviewerHtml: nextHtml,
+        lastUpdatedBy: reviewer.email || reviewer.name || reviewer.sub || 'reviewer',
+        lastUpdatedAt: updatedAt,
+        reviewerName: reviewer.name || record.reviewerName || null
+      }
+    });
+    if (updated?.chunkId) {
+      chunkMap.set(updated.chunkId, updated);
+    }
   }
 
-  chunkData.lastReviewedAt = updatedAt;
-  chunkData.chunks = Array.from(chunkMap.values());
-  await saveChunks(item.chunkFileKey, chunkData);
-  await updateTranslation(translationId, ownerId, { lastReviewedAt: updatedAt });
-  return chunkData;
+  const sortedRecords = Array.from(chunkMap.values()).sort((a, b) => (a.order || 0) - (b.order || 0));
+  const normalized = sortedRecords.map(normaliseChunkRecord);
+  await persistChunkPayload(item, ownerId, normalized);
+
+  const summary = summariseChunks(sortedRecords);
+  await updateTranslation(translationId, ownerId, {
+    lastReviewedAt: updatedAt,
+    processedChunks: summary.completed,
+    failedChunks: summary.failed
+  });
+
+  return {
+    headHtml: item.headHtml,
+    chunks: normalized,
+    lastReviewedAt: updatedAt,
+    sourceLanguage: item.sourceLanguage,
+    targetLanguage: item.targetLanguage
+  };
 }
 
 async function handleApprove(translationId, ownerId, reviewer) {
   const item = await getTranslation(translationId, ownerId);
-  if (!item?.chunkFileKey) {
-    throw new Error('No chunk file found for translation');
+  if (!item) {
+    throw new Error('Translation not found');
   }
-  const chunkData = await loadChunks(item.chunkFileKey);
-  const finalHtml = assembleHtmlDocument({ headHtml: chunkData.headHtml, chunks: chunkData.chunks, reviewer: true });
+  const records = await listChunks(translationId, ownerId);
+  if (!records.length) {
+    throw new Error('No chunk data found for translation');
+  }
+  const normalized = records
+    .sort((a, b) => (a.order || 0) - (b.order || 0))
+    .map(normaliseChunkRecord);
+  const finalHtml = assembleHtmlDocument({ headHtml: item.headHtml, chunks: normalized, reviewer: true });
   const htmlKey = `translations/output/${ownerId}/${translationId}.html`;
   await s3.send(new PutObjectCommand({ Bucket: RAW_BUCKET, Key: htmlKey, Body: finalHtml, ContentType: 'text/html; charset=utf-8' }));
 
@@ -361,6 +433,7 @@ async function handleDelete(translationId, ownerId) {
   ]);
 
   // Delete DynamoDB record
+  await deleteAllChunks(translationId, ownerId);
   await ddb.send(new DeleteItemCommand({
     TableName: DOCS_TABLE,
     Key: marshall({ PK: `TRANSLATION#${translationId}`, SK: `TRANSLATION#${ownerId}` })
@@ -430,12 +503,20 @@ exports.handler = async (event, context, callback) => {
 
     if (method === 'GET' && path.endsWith('/chunks')) {
       const item = await getTranslation(translationId, ownerId);
-      if (!item?.chunkFileKey) {
+      if (!item) {
+        return ok(404, { message: 'Translation not found' }, callback);
+      }
+      const chunks = await fetchChunkState(item, ownerId);
+      if (!chunks) {
         return ok(404, { message: 'No chunks found' }, callback);
       }
-      console.log('fetching chunks', { translationId, chunkFileKey: item.chunkFileKey });
-      const chunkData = await loadChunks(item.chunkFileKey);
-      return ok(200, chunkData, callback);
+      return ok(200, {
+        translationId,
+        headHtml: item.headHtml,
+        sourceLanguage: item.sourceLanguage,
+        targetLanguage: item.targetLanguage,
+        chunks
+      }, callback);
     }
 
     if (method === 'PUT' && path.endsWith('/chunks')) {


### PR DESCRIPTION
## Summary
- persist translation chunks per document in DynamoDB and resume translation work safely while regenerating S3 artifacts on completion
- add shared notification helper with SES delivery and expose admin-configurable preferences via API and UI
- schedule a job health check lambda to restart stalled translations/ingestions and expand infrastructure with SES configuration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7e9d8bcbc83318c06235a1db13d04