### PR TITLE
Revamp translation review workspace

### DIFF
--- a/frontend/admin/lib/api.ts
+++ b/frontend/admin/lib/api.ts
@@ -215,7 +215,16 @@ export async function approveTranslation(translationId: string){
   return res.json() as Promise<{ status: string; translatedFileKey?: string }>;
 }
 
-export async function getTranslationDownloadUrl(translationId: string, type: 'original' | 'machine' | 'translated' | 'translatedHtml' = 'original'){
+export async function getTranslationDownloadUrl(
+  translationId: string,
+  type:
+    | 'original'
+    | 'machine'
+    | 'translated'
+    | 'translatedHtml'
+    | 'translatedDocx'
+    | 'translatedPdf' = 'original'
+){
   const res = await fetch(`${cfg.apiBase}/translations/${encodeURIComponent(translationId)}/download?type=${encodeURIComponent(type)}`, {
     headers: { ...(await authHeader()) }
   });

--- a/frontend/admin/pages/translations/[translationId].tsx
+++ b/frontend/admin/pages/translations/[translationId].tsx
@@ -16,103 +16,51 @@ type ChunkStatus = {
   message?: string;
 };
 
+type DownloadType =
+  | 'original'
+  | 'machine'
+  | 'translated'
+  | 'translatedHtml'
+  | 'translatedDocx'
+  | 'translatedPdf';
+
 export default function TranslationDetailPage() {
   const router = useRouter();
   const { translationId } = router.query as { translationId?: string };
+
+  // Server state
   const [translation, setTranslation] = useState<TranslationItem | null>(null);
   const [chunks, setChunks] = useState<TranslationChunk[]>([]);
-  const [drafts, setDrafts] = useState<Record<string, string>>({});
-  const draftsRef = useRef<Record<string, string>>({});
   const chunksRef = useRef<TranslationChunk[]>([]);
-  const [chunkStatuses, setChunkStatuses] = useState<Record<string, ChunkStatus>>({});
+
+  // Editor state
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [approving, setApproving] = useState(false);
   const [reviewLocked, setReviewLocked] = useState(false);
   const [chunkNotice, setChunkNotice] = useState<string | null>(null);
   const [activeChunkId, setActiveChunkId] = useState<string | null>(null);
-  const [editingChunkId, setEditingChunkId] = useState<string | null>(null);
+  const [chunkStatuses, setChunkStatuses] = useState<Record<string, ChunkStatus>>({});
+  const [syncScroll, setSyncScroll] = useState(true);
+
+  // Initial markup to render once; live edits happen in DOM (contenteditable)
+  const [sourceMarkup, setSourceMarkup] = useState<string>('');
+  const [targetMarkup, setTargetMarkup] = useState<string>('');
+
+  // Refs to panes/docs
+  const leftPaneRef = useRef<HTMLDivElement | null>(null);
+  const rightPaneRef = useRef<HTMLDivElement | null>(null);
+  const sourceDocRef = useRef<HTMLElement | null>(null);
+  const targetDocRef = useRef<HTMLElement | null>(null);
+
+  // Debounced autosave timers per chunk
   const saveTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+  // The current draft HTML per chunk (kept off React render loop to avoid thrash)
+  const draftsRef = useRef<Record<string, string>>({});
+  // Guard to avoid scroll loops
+  const syncingRef = useRef(false);
 
-  useEffect(() => {
-    draftsRef.current = drafts;
-  }, [drafts]);
-
-  useEffect(() => {
-    chunksRef.current = chunks;
-  }, [chunks]);
-
-  useEffect(() => {
-    if (!translationId) return;
-    let cancelled = false;
-    async function load() {
-      setLoading(true);
-      setReviewLocked(false);
-      setChunkNotice(null);
-      setEditingChunkId(null);
-      setActiveChunkId(null);
-      try {
-        const t = await getTranslation(translationId);
-        if (cancelled) return;
-        setTranslation(t);
-        const data = await getTranslationChunks(translationId);
-        if (cancelled) return;
-        setReviewLocked(Boolean(data.reviewLocked));
-        setChunkNotice(data.message || null);
-        const ordered = (data.chunks || []).sort((a, b) => (a.order || 0) - (b.order || 0));
-        setChunks(ordered);
-        if (!data.reviewLocked) {
-          const nextDrafts: Record<string, string> = {};
-          const nextStatuses: Record<string, ChunkStatus> = {};
-          ordered.forEach(chunk => {
-            nextDrafts[chunk.id] = chunk.reviewerHtml || chunk.machineHtml || chunk.sourceHtml;
-            nextStatuses[chunk.id] = { state: 'idle' };
-          });
-          setDrafts(nextDrafts);
-          setChunkStatuses(nextStatuses);
-          setActiveChunkId(ordered[0]?.id ?? null);
-        } else {
-          setDrafts({});
-          setChunkStatuses({});
-        }
-      } catch (err: any) {
-        if (cancelled) return;
-        if (typeof err?.message === 'string' && err.message.includes('404')) {
-          setChunks([]);
-          setDrafts({});
-          setChunkStatuses({});
-          setChunkNotice('Chunks are not available yet.');
-        } else {
-          setError(err?.message || 'Failed to load translation');
-        }
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
-      }
-    }
-    load();
-    return () => {
-      cancelled = true;
-    };
-  }, [translationId]);
-
-  useEffect(() => {
-    setChunkStatuses(prev => {
-      const next: Record<string, ChunkStatus> = {};
-      let changed = false;
-      chunks.forEach(chunk => {
-        const existing = prev[chunk.id];
-        next[chunk.id] = existing || { state: 'idle' };
-        if (!existing) changed = true;
-      });
-      if (Object.keys(prev).length !== Object.keys(next).length) {
-        changed = true;
-      }
-      return changed ? next : prev;
-    });
-  }, [chunks]);
-
+  // Computed flags
   const canEditChunks = useMemo(
     () => translation?.status === 'READY_FOR_REVIEW' && !reviewLocked,
     [translation, reviewLocked]
@@ -123,39 +71,145 @@ export default function TranslationDetailPage() {
     [translation]
   );
 
+  // ---- Load translation + chunks ------------------------------------------------
+  useEffect(() => {
+    if (!translationId) return;
+    let cancelled = false;
+
+    async function load() {
+      setLoading(true);
+      setError(null);
+      setActiveChunkId(null);
+      setSourceMarkup('');
+      setTargetMarkup('');
+      draftsRef.current = {};
+      setChunkStatuses({});
+      try {
+        const t = await getTranslation(translationId);
+        if (cancelled) return;
+        setTranslation(t);
+
+        const data = await getTranslationChunks(translationId);
+        if (cancelled) return;
+
+        setReviewLocked(Boolean(data.reviewLocked));
+        setChunkNotice(data.message || null);
+
+        const ordered: TranslationChunk[] = (data.chunks || []).sort(
+          (a, b) => (a.order || 0) - (b.order || 0)
+        );
+        setChunks(ordered);
+        chunksRef.current = ordered;
+
+        // Prepare invisible segment wrappers for both docs
+        const srcMarkup = ordered
+          .map((c) => `<section class="seg" data-seg="${c.id}">${c.sourceHtml || ''}</section>`)
+          .join('\n');
+
+        setSourceMarkup(srcMarkup);
+
+        if (!data.reviewLocked) {
+          // Initial translation HTML (reviewerHtml > machineHtml > sourceHtml)
+          const tgtMarkup = ordered
+            .map((c) => {
+              const html = c.reviewerHtml || c.machineHtml || c.sourceHtml || '';
+              draftsRef.current[c.id] = html;
+              return `<section class="seg" data-seg="${c.id}">${html}</section>`;
+            })
+            .join('\n');
+
+          // Init all statuses to idle
+          const nextStatuses: Record<string, ChunkStatus> = {};
+          ordered.forEach((c) => (nextStatuses[c.id] = { state: 'idle' }));
+          setChunkStatuses(nextStatuses);
+
+          setTargetMarkup(tgtMarkup);
+          setActiveChunkId(ordered[0]?.id ?? null);
+        } else {
+          setTargetMarkup(
+            ordered
+              .map((c) => `<section class="seg" data-seg="${c.id}">${c.reviewerHtml || c.machineHtml || c.sourceHtml || ''}</section>`)
+              .join('\n')
+          );
+          setActiveChunkId(ordered[0]?.id ?? null);
+        }
+      } catch (err: any) {
+        if (cancelled) return;
+        if (typeof err?.message === 'string' && err.message.includes('404')) {
+          setChunks([]);
+          setSourceMarkup('');
+          setTargetMarkup('');
+          setChunkNotice('Chunks are not available yet.');
+        } else {
+          setError(err?.message || 'Failed to load translation');
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [translationId]);
+
+  // Keep chunksRef in sync
+  useEffect(() => {
+    chunksRef.current = chunks;
+  }, [chunks]);
+
+  // ---- Autosave -----------------------------------------------------------------
   const persistChunk = useCallback(
     async (chunkId: string) => {
       if (!translationId || !canEditChunks) return;
+
       const timers = saveTimers.current;
       if (timers[chunkId]) {
         clearTimeout(timers[chunkId]);
         delete timers[chunkId];
       }
-      const payload = draftsRef.current[chunkId] ?? '';
-      const existing = chunksRef.current.find(chunk => chunk.id === chunkId);
-      const currentHtml = existing?.reviewerHtml || existing?.machineHtml || existing?.sourceHtml || '';
+
+      // Current DOM payload for this segment (from the live editor)
+      const seg = targetDocRef.current?.querySelector<HTMLElement>(`.seg[data-seg="${chunkId}"]`);
+      const payload = seg?.innerHTML ?? draftsRef.current[chunkId] ?? '';
+
+      // Compare with server-side current html to avoid no-op saves
+      const existing = chunksRef.current.find((c) => c.id === chunkId);
+      const currentHtml =
+        existing?.reviewerHtml || existing?.machineHtml || existing?.sourceHtml || '';
+
       if (payload === currentHtml) {
-        setChunkStatuses(prev => ({ ...prev, [chunkId]: { state: 'saved' } }));
+        setChunkStatuses((prev) => ({ ...prev, [chunkId]: { state: 'saved' } }));
+        draftsRef.current[chunkId] = payload;
         return;
       }
+
       setError(null);
-      setChunkStatuses(prev => ({ ...prev, [chunkId]: { state: 'saving' } }));
+      setChunkStatuses((prev) => ({ ...prev, [chunkId]: { state: 'saving' } }));
+
       try {
-        const res = await updateTranslationChunks(translationId, [{ id: chunkId, reviewerHtml: payload }]);
+        const res = await updateTranslationChunks(translationId, [
+          { id: chunkId, reviewerHtml: payload },
+        ]);
+
         const updatedMap: Record<string, TranslationChunk> = {};
-        (res.chunks || []).forEach(chunk => {
-          updatedMap[chunk.id] = chunk;
-        });
-        setChunks(prev => prev.map(chunk => updatedMap[chunk.id] || chunk));
-        const saved = updatedMap[chunkId];
-        if (saved) {
-          setDrafts(prev => ({ ...prev, [chunkId]: saved.reviewerHtml || saved.machineHtml || saved.sourceHtml || '' }));
-        }
-        setChunkStatuses(prev => ({ ...prev, [chunkId]: { state: 'saved' } }));
+        (res.chunks || []).forEach((c: TranslationChunk) => (updatedMap[c.id] = c));
+
+        setChunks((prev) => prev.map((c) => updatedMap[c.id] || c));
+        chunksRef.current = chunksRef.current.map((c) => updatedMap[c.id] || c);
+
+        draftsRef.current[chunkId] =
+          updatedMap[chunkId]?.reviewerHtml ||
+          updatedMap[chunkId]?.machineHtml ||
+          updatedMap[chunkId]?.sourceHtml ||
+          payload;
+
+        setChunkStatuses((prev) => ({ ...prev, [chunkId]: { state: 'saved' } }));
       } catch (err: any) {
         const message = err?.message || 'Save failed';
         setError(message);
-        setChunkStatuses(prev => ({ ...prev, [chunkId]: { state: 'error', message } }));
+        setChunkStatuses((prev) => ({ ...prev, [chunkId]: { state: 'error', message } }));
       }
     },
     [translationId, canEditChunks]
@@ -165,32 +219,230 @@ export default function TranslationDetailPage() {
     (chunkId: string) => {
       if (!canEditChunks) return;
       const timers = saveTimers.current;
-      if (timers[chunkId]) {
-        clearTimeout(timers[chunkId]);
-      }
-      timers[chunkId] = setTimeout(() => {
-        void persistChunk(chunkId);
-      }, 800);
+      if (timers[chunkId]) clearTimeout(timers[chunkId]);
+      timers[chunkId] = setTimeout(() => void persistChunk(chunkId), 800);
     },
     [canEditChunks, persistChunk]
   );
 
+  // Flush any pending saves on unmount/route-change
   useEffect(() => {
     return () => {
-      Object.values(saveTimers.current).forEach(timer => clearTimeout(timer));
+      Object.values(saveTimers.current).forEach((t) => clearTimeout(t));
+      // Fire a last "best effort" save for all segments
+      chunksRef.current.forEach((c) => void persistChunk(c.id));
     };
+  }, [persistChunk]);
+
+  // ---- Editing interactions (contenteditable) -----------------------------------
+  // Highlight linked segments on both sides
+  const applyActiveHighlight = useCallback(
+    (id: string | null) => {
+      if (!id) return;
+      const removeAll = (root: Element | null) => {
+        if (!root) return;
+        root.querySelectorAll('.seg.active').forEach((el) => el.classList.remove('active'));
+      };
+      removeAll(sourceDocRef.current || null);
+      removeAll(targetDocRef.current || null);
+
+      const src = sourceDocRef.current?.querySelector(`.seg[data-seg="${id}"]`);
+      const tgt = targetDocRef.current?.querySelector(`.seg[data-seg="${id}"]`);
+      if (src) src.classList.add('active');
+      if (tgt) tgt.classList.add('active');
+    },
+    []
+  );
+
+  // Translate a DOM node to its enclosing segment id
+  const nodeToSegId = (node: Node | null): string | null => {
+    if (!node) return null;
+    // If it's a text node, use the parent element
+    let el: Element | null =
+      node.nodeType === Node.ELEMENT_NODE ? (node as Element) : (node.parentElement as Element | null);
+    if (!el) return null;
+    const seg = el.closest('.seg') as HTMLElement | null;
+    return seg ? seg.dataset.seg || null : null;
+  };
+
+  // Place caret at start of element
+  const placeCaretAtStart = (el: Node) => {
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    range.collapse(true);
+    const sel = window.getSelection();
+    if (!sel) return;
+    sel.removeAllRanges();
+    sel.addRange(range);
+  };
+
+  // After markup is rendered into DOM, wire up listeners
+  useEffect(() => {
+    // Nothing to wire until both sides are present
+    if (!sourceMarkup || !targetMarkup) return;
+
+    const $src = sourceDocRef.current!;
+    const $tgt = targetDocRef.current!;
+
+    // Sync current active highlight
+    if (activeChunkId) applyActiveHighlight(activeChunkId);
+
+    // On clicks/selection moves inside the editable doc, set active + highlight
+    const handleTargetActivity = () => {
+      const sel = window.getSelection();
+      const id = nodeToSegId(sel?.anchorNode || null);
+      if (!id) return;
+      setActiveChunkId(id);
+      applyActiveHighlight(id);
+
+      // When selection changes, also ensure the source segment scrolls into view
+      const srcSeg = $src.querySelector(`.seg[data-seg="${id}"]`);
+      if (srcSeg) (srcSeg as HTMLElement).scrollIntoView({ behavior: 'smooth', block: 'center' });
+    };
+
+    const handleTargetInput = (e: Event) => {
+      if (!canEditChunks) return;
+      const target = e.target as HTMLElement;
+      const seg = target.closest('.seg') as HTMLElement | null;
+      if (!seg || !seg.dataset.seg) return;
+      const id = seg.dataset.seg;
+      draftsRef.current[id] = seg.innerHTML;
+      setChunkStatuses((prev) => ({ ...prev, [id]: { state: 'saving' } }));
+      scheduleSave(id);
+    };
+
+    const handleSourceClick = (e: MouseEvent) => {
+      const el = e.target as HTMLElement;
+      const seg = el.closest('.seg') as HTMLElement | null;
+      if (!seg || !seg.dataset.seg) return;
+      const id = seg.dataset.seg;
+      setActiveChunkId(id);
+      applyActiveHighlight(id);
+      const tgtSeg = $tgt.querySelector(`.seg[data-seg="${id}"]`) as HTMLElement | null;
+      if (tgtSeg) {
+        tgtSeg.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        placeCaretAtStart(tgtSeg);
+      }
+    };
+
+    // Keyboard quick‑nav Alt+↑ / Alt+↓
+    const handleKeyNav = (e: KeyboardEvent) => {
+      if (!e.altKey || (e.key !== 'ArrowUp' && e.key !== 'ArrowDown')) return;
+      e.preventDefault();
+      const ids = chunksRef.current.map((c) => c.id);
+      const idx = Math.max(0, ids.indexOf(activeChunkId || ids[0]));
+      const nextIdx =
+        e.key === 'ArrowDown' ? Math.min(ids.length - 1, idx + 1) : Math.max(0, idx - 1);
+      const nextId = ids[nextIdx];
+      if (!nextId) return;
+      setActiveChunkId(nextId);
+      applyActiveHighlight(nextId);
+      const tgtSeg = $tgt.querySelector(`.seg[data-seg="${nextId}"]`) as HTMLElement | null;
+      if (tgtSeg) {
+        tgtSeg.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        placeCaretAtStart(tgtSeg);
+      }
+    };
+
+    $tgt.addEventListener('click', handleTargetActivity);
+    $tgt.addEventListener('keyup', handleTargetActivity);
+    $tgt.addEventListener('mouseup', handleTargetActivity);
+    $tgt.addEventListener('input', handleTargetInput);
+    $src.addEventListener('click', handleSourceClick);
+    document.addEventListener('keydown', handleKeyNav);
+
+    return () => {
+      $tgt.removeEventListener('click', handleTargetActivity);
+      $tgt.removeEventListener('keyup', handleTargetActivity);
+      $tgt.removeEventListener('mouseup', handleTargetActivity);
+      $tgt.removeEventListener('input', handleTargetInput);
+      $src.removeEventListener('click', handleSourceClick);
+      document.removeEventListener('keydown', handleKeyNav);
+    };
+  }, [sourceMarkup, targetMarkup, canEditChunks, activeChunkId, applyActiveHighlight, scheduleSave]);
+
+  // Keep visual highlight synced if active id changes outside of the effect above
+  useEffect(() => {
+    applyActiveHighlight(activeChunkId);
+  }, [activeChunkId, applyActiveHighlight]);
+
+  // ---- Scroll sync between panes ------------------------------------------------
+  useEffect(() => {
+    const left = leftPaneRef.current;
+    const right = rightPaneRef.current;
+    if (!left || !right) return;
+
+    const onScroll = (src: HTMLElement, dst: HTMLElement) => {
+      if (!syncScroll) return;
+      if (syncingRef.current) return;
+      syncingRef.current = true;
+      const ratio = src.scrollTop / (src.scrollHeight - src.clientHeight || 1);
+      dst.scrollTop = ratio * (dst.scrollHeight - dst.clientHeight);
+      requestAnimationFrame(() => (syncingRef.current = false));
+    };
+
+    const handleLeftScroll = () => onScroll(left, right);
+    const handleRightScroll = () => onScroll(right, left);
+
+    left.addEventListener('scroll', handleLeftScroll);
+    right.addEventListener('scroll', handleRightScroll);
+    return () => {
+      left.removeEventListener('scroll', handleLeftScroll);
+      right.removeEventListener('scroll', handleRightScroll);
+    };
+  }, [syncScroll, sourceMarkup, targetMarkup]);
+
+  // ---- Divider drag for resizing ------------------------------------------------
+  const gridRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const divider = document.getElementById('divider-bar');
+    if (!divider || !gridRef.current) return;
+
+    let startX = 0;
+    let startLeftFr = 1;
+
+    const getCols = () => {
+      const style = window.getComputedStyle(gridRef.current!);
+      const [left, gap, right] = style.gridTemplateColumns.split(' ');
+      return [parseFloat(left), gap, parseFloat(right)];
+    };
+
+    const setCols = (leftFr: number) => {
+      const left = Math.min(80, Math.max(20, leftFr));
+      const right = 100 - left;
+      gridRef.current!.style.gridTemplateColumns = `${left}fr 10px ${right}fr`;
+    };
+
+    const onMouseMove = (e: MouseEvent) => {
+      const dx = e.clientX - startX;
+      const total = window.innerWidth || 1;
+      setCols(startLeftFr + (dx / total) * 100);
+    };
+
+    const onMouseUp = () => {
+      document.body.style.cursor = '';
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', onMouseUp);
+    };
+
+    const onMouseDown = (e: MouseEvent) => {
+      const [left] = getCols();
+      startLeftFr = left;
+      startX = e.clientX;
+      document.body.style.cursor = 'col-resize';
+      window.addEventListener('mousemove', onMouseMove);
+      window.addEventListener('mouseup', onMouseUp, { once: true });
+    };
+
+    divider.addEventListener('mousedown', onMouseDown);
+    return () => divider.removeEventListener('mousedown', onMouseDown);
   }, []);
 
-  useEffect(() => {
-    if (!canEditChunks) {
-      Object.values(saveTimers.current).forEach(timer => clearTimeout(timer));
-      saveTimers.current = {};
-      setEditingChunkId(null);
-    }
-  }, [canEditChunks]);
-
+  // ---- Actions ------------------------------------------------------------------
   async function approve() {
     if (!translationId) return;
+    // Flush all pending edits first
+    chunksRef.current.forEach((c) => void persistChunk(c.id));
     setApproving(true);
     setError(null);
     try {
@@ -198,49 +450,24 @@ export default function TranslationDetailPage() {
       const updated = await getTranslation(translationId);
       setTranslation(updated);
       try {
-        const chunkData = await getTranslationChunks(translationId);
-        setReviewLocked(Boolean(chunkData.reviewLocked));
-        setChunkNotice(chunkData.message || 'Translation has been approved.');
-        const ordered = (chunkData.chunks || []).sort((a, b) => (a.order || 0) - (b.order || 0));
+        const data = await getTranslationChunks(translationId);
+        setReviewLocked(Boolean(data.reviewLocked));
+        setChunkNotice(data.message || 'Translation has been approved.');
+        const ordered = (data.chunks || []).sort((a, b) => (a.order || 0) - (b.order || 0));
         setChunks(ordered);
-        if (!chunkData.reviewLocked) {
-          const nextDrafts: Record<string, string> = {};
-          const nextStatuses: Record<string, ChunkStatus> = {};
-          ordered.forEach(chunk => {
-            nextDrafts[chunk.id] = chunk.reviewerHtml || chunk.machineHtml || chunk.sourceHtml;
-            nextStatuses[chunk.id] = { state: 'idle' };
-          });
-          setDrafts(nextDrafts);
-          setChunkStatuses(nextStatuses);
-          setActiveChunkId(ordered[0]?.id ?? null);
-        } else {
-          setDrafts({});
-          setChunkStatuses({});
-          setActiveChunkId(null);
-        }
+        chunksRef.current = ordered;
       } catch {
         setReviewLocked(true);
         setChunkNotice('Translation has been approved. Chunk data is no longer available.');
         setChunks([]);
-        setDrafts({});
-        setChunkStatuses({});
-        setActiveChunkId(null);
+        chunksRef.current = [];
       }
-      setEditingChunkId(null);
     } catch (err: any) {
       setError(err?.message || 'Approval failed');
     } finally {
       setApproving(false);
     }
   }
-
-  type DownloadType =
-    | 'original'
-    | 'machine'
-    | 'translated'
-    | 'translatedHtml'
-    | 'translatedDocx'
-    | 'translatedPdf';
 
   async function download(type: DownloadType) {
     if (!translationId) return;
@@ -251,6 +478,23 @@ export default function TranslationDetailPage() {
       setError(err?.message || 'Download failed');
     }
   }
+
+  // Prev/Next buttons (navigate across segments)
+  const jumpTo = (dir: 'prev' | 'next') => {
+    const ids = chunksRef.current.map((c) => c.id);
+    if (!ids.length) return;
+    const idx = Math.max(0, ids.indexOf(activeChunkId || ids[0]));
+    const nextIdx = dir === 'next' ? Math.min(ids.length - 1, idx + 1) : Math.max(0, idx - 1);
+    const id = ids[nextIdx];
+    if (!id) return;
+    setActiveChunkId(id);
+    // Scroll + move caret
+    const tgtSeg = targetDocRef.current?.querySelector(`.seg[data-seg="${id}"]`) as HTMLElement | null;
+    if (tgtSeg) {
+      tgtSeg.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      placeCaretAtStart(tgtSeg);
+    }
+  };
 
   if (!translationId) {
     return (
@@ -264,19 +508,32 @@ export default function TranslationDetailPage() {
     <Layout>
       {loading && <div className="muted">Loading…</div>}
       {error && (
-        <div className="chip" style={{ borderColor: 'var(--danger)', background: 'rgba(220,38,38,.08)', marginBottom: 16 }}>
+        <div
+          className="chip"
+          style={{
+            borderColor: 'var(--danger)',
+            background: 'rgba(220,38,38,.08)',
+            marginBottom: 16,
+          }}
+        >
           {error}
         </div>
       )}
+
       {translation && (
-        <div className="card" style={{ marginBottom: 24 }}>
+        <div className="card" style={{ marginBottom: 16 }}>
           <div className="row" style={{ justifyContent: 'space-between', alignItems: 'flex-start' }}>
             <div>
-              <h2 style={{ marginBottom: 6 }}>{translation.title || translation.originalFilename}</h2>
+              <h2 style={{ marginBottom: 6 }}>
+                {translation.title || translation.originalFilename}
+              </h2>
               <div className="muted">
-                {translation.sourceLanguage?.toUpperCase()} → {translation.targetLanguage?.toUpperCase()}
+                {translation.sourceLanguage?.toUpperCase()} →{' '}
+                {translation.targetLanguage?.toUpperCase()}
               </div>
-              <div className="muted mini" style={{ marginTop: 4 }}>Status: {translation.status}</div>
+              <div className="muted mini" style={{ marginTop: 4 }}>
+                Status: {translation.status}
+              </div>
             </div>
             <div className="row" style={{ gap: 8, flexWrap: 'wrap' }}>
               <button className="btn ghost mini" onClick={() => download('original')}>
@@ -300,148 +557,132 @@ export default function TranslationDetailPage() {
         </div>
       )}
 
+      {/* Compare Shell */}
       {translation?.status === 'READY_FOR_REVIEW' ? (
         reviewLocked ? (
           <div className="card">
             <div className="muted">Translation review is currently read-only.</div>
-            {chunkNotice && <div className="muted mini" style={{ marginTop: 8 }}>{chunkNotice}</div>}
+            {chunkNotice && (
+              <div className="muted mini" style={{ marginTop: 8 }}>
+                {chunkNotice}
+              </div>
+            )}
           </div>
         ) : (
           <>
-            <div className="card compare-header">
-              <div>
-                <div className="badge">Document Compare — Source ↔ Translation</div>
-                <div className="muted mini" style={{ marginTop: 4 }}>
-                  Click anywhere in the Translation panel to edit that section. Matching source content highlights automatically.
-                </div>
-                <div className="muted mini" style={{ marginTop: 4 }}>
-                  Changes are autosaved as one continuous document.
-                </div>
-              </div>
-              {canExportTranslation && (
-                <div className="export-actions">
-                  <button className="btn" onClick={() => download('translatedDocx')}>
-                    Export DOCX
+            {/* Sticky top bar (matches the prototype) */}
+            <div className="compare-shell">
+              <header className="topbar">
+                <div className="bar">
+                  <div className="title">Document Compare — Source ↔ Translation</div>
+                  <label className="check">
+                    <input
+                      type="checkbox"
+                      checked={syncScroll}
+                      onChange={(e) => setSyncScroll(e.target.checked)}
+                    />
+                    Sync scroll
+                  </label>
+                  <button className="btn" onClick={() => jumpTo('prev')} title="Alt+↑">
+                    Prev match
                   </button>
-                  <button className="btn ghost" onClick={() => download('translatedPdf')}>
-                    Export PDF
+                  <button className="btn" onClick={() => jumpTo('next')} title="Alt+↓">
+                    Next match
                   </button>
+                  {canExportTranslation && (
+                    <>
+                      <button className="btn primary" onClick={() => download('translatedDocx')}>
+                        Export Translation
+                      </button>
+                      <button className="btn ghost" onClick={() => download('translatedPdf')}>
+                        PDF
+                      </button>
+                    </>
+                  )}
                 </div>
-              )}
+                <div className="hint">
+                  Click anywhere in the <strong>Translation</strong> (right). The matching passage in
+                  the <strong>Source</strong> (left) will highlight for context. The translation is
+                  fully editable as one continuous document.
+                </div>
+              </header>
+
+              {/* Grid panes with draggable divider */}
+              <main className="grid" ref={gridRef} id="compare-grid">
+                <section className="pane" ref={leftPaneRef}>
+                  <div className="paneHeader">Source (read‑only)</div>
+                  <article
+                    className="doc"
+                    ref={sourceDocRef as any}
+                    // render once; contents are plain HTML from server
+                    dangerouslySetInnerHTML={{ __html: sourceMarkup }}
+                  />
+                </section>
+
+                <div
+                  id="divider-bar"
+                  className="divider"
+                  role="separator"
+                  aria-orientation="vertical"
+                  aria-label="Resize panes"
+                />
+
+                <section className="pane" ref={rightPaneRef}>
+                  <div className="paneHeader">
+                    <div>Translation (editable)</div>
+                    {/* Status for the active segment */}
+                    {activeChunkId && (
+                      <div className="statusLine">
+                        {chunkStatuses[activeChunkId]?.state === 'saving' && (
+                          <span className="status saving">Saving…</span>
+                        )}
+                        {chunkStatuses[activeChunkId]?.state === 'saved' && (
+                          <span className="status saved">Autosaved</span>
+                        )}
+                        {chunkStatuses[activeChunkId]?.state === 'error' && (
+                          <span className="status error">
+                            {chunkStatuses[activeChunkId]?.message || 'Autosave failed'}
+                          </span>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                  <article
+                    className="doc"
+                    id="targetDoc"
+                    ref={targetDocRef as any}
+                    contentEditable={!!canEditChunks}
+                    suppressContentEditableWarning
+                    spellCheck={false}
+                    dangerouslySetInnerHTML={{ __html: targetMarkup }}
+                  />
+                </section>
+              </main>
             </div>
             {chunkNotice && (
-              <div className="card info-note">
+              <div className="card info-note" style={{ marginTop: 12 }}>
                 <div className="muted mini">{chunkNotice}</div>
               </div>
             )}
-            <div className="compare-layout">
-              <section className="panel source-panel">
-                <header className="panel-heading">
-                  <div>
-                    <h3>Source (read-only)</h3>
-                    <p className="muted mini">Use this for context while you revise.</p>
-                  </div>
-                </header>
-                <div className="panel-body">
-                  {chunks.map(chunk => (
-                    <article
-                      key={chunk.id}
-                      className={`source-section ${activeChunkId === chunk.id ? 'active' : ''}`}
-                      onClick={() => setActiveChunkId(chunk.id)}
-                    >
-                      <div className="section-label">Section {chunk.order}</div>
-                      <div className="section-html" dangerouslySetInnerHTML={{ __html: chunk.sourceHtml }} />
-                    </article>
-                  ))}
-                  {!chunks.length && <div className="muted mini">No sections available yet.</div>}
-                </div>
-              </section>
-              <section className="panel translation-panel">
-                <header className="panel-heading">
-                  <div>
-                    <h3>Translation</h3>
-                    <p className="muted mini">Select a section to revise the translation. Keep HTML structure intact when editing.</p>
-                  </div>
-                </header>
-                <div className="panel-body">
-                  {chunks.map(chunk => {
-                    const draft = drafts[chunk.id] ?? '';
-                    const status = chunkStatuses[chunk.id] || { state: 'idle' };
-                    const isEditing = editingChunkId === chunk.id;
-                    const translationHtml = draft || '';
-                    return (
-                      <article
-                        key={chunk.id}
-                        className={`translation-section ${activeChunkId === chunk.id ? 'active' : ''}`}
-                        onClick={() => setActiveChunkId(chunk.id)}
-                      >
-                        <div className="section-header">
-                          <div className="section-label">Section {chunk.order}</div>
-                          <div className="section-meta">
-                            {status.state === 'saving' && <span className="status saving">Saving…</span>}
-                            {status.state === 'saved' && <span className="status saved">Autosaved</span>}
-                            {status.state === 'error' && <span className="status error">{status.message || 'Autosave failed'}</span>}
-                            <button
-                              className="btn ghost mini"
-                              disabled={!canEditChunks}
-                              onClick={e => {
-                                e.stopPropagation();
-                                if (isEditing) {
-                                  setEditingChunkId(null);
-                                  void persistChunk(chunk.id);
-                                } else {
-                                  setEditingChunkId(chunk.id);
-                                  setActiveChunkId(chunk.id);
-                                }
-                              }}
-                            >
-                              {isEditing ? 'Done' : 'Edit'}
-                            </button>
-                          </div>
-                        </div>
-                        {isEditing ? (
-                          <textarea
-                            className="translation-textarea"
-                            value={draft}
-                            onChange={e => {
-                              const value = e.target.value;
-                              setDrafts(prev => ({ ...prev, [chunk.id]: value }));
-                              setChunkStatuses(prev => ({ ...prev, [chunk.id]: { state: 'saving' } }));
-                              scheduleSave(chunk.id);
-                            }}
-                            onFocus={() => setActiveChunkId(chunk.id)}
-                            onBlur={() => {
-                              void persistChunk(chunk.id);
-                            }}
-                            rows={Math.max(8, Math.ceil(Math.max(draft.length, 1) / 120))}
-                            disabled={!canEditChunks}
-                          />
-                        ) : (
-                          <div className="section-html translation-preview" dangerouslySetInnerHTML={{ __html: translationHtml }} />
-                        )}
-                        {!isEditing && (
-                          <div className="muted mini" style={{ marginTop: 8 }}>
-                            Click Edit to revise this section. Changes are saved automatically.
-                          </div>
-                        )}
-                      </article>
-                    );
-                  })}
-                  {!chunks.length && <div className="muted mini">No translated sections yet.</div>}
-                </div>
-              </section>
-            </div>
           </>
         )
       ) : isApproved ? (
         <div className="card">
           <div className="muted">Translation has been approved. Chunk data has been removed.</div>
-          {chunkNotice && <div className="muted mini" style={{ marginTop: 8 }}>{chunkNotice}</div>}
+          {chunkNotice && (
+            <div className="muted mini" style={{ marginTop: 8 }}>
+              {chunkNotice}
+            </div>
+          )}
         </div>
       ) : translation?.status === 'FAILED' ? (
         <div className="card">
           <div className="muted">Translation failed.</div>
-          {translation.errorMessage && <div className="muted mini" style={{ marginTop: 8 }}>{translation.errorMessage}</div>}
+          {translation.errorMessage && (
+            <div className="muted mini" style={{ marginTop: 8 }}>
+              {translation.errorMessage}
+            </div>
+          )}
         </div>
       ) : (
         <div className="card">
@@ -450,114 +691,167 @@ export default function TranslationDetailPage() {
       )}
 
       <style jsx>{`
-        .compare-header {
-          display: flex;
-          align-items: flex-start;
-          justify-content: space-between;
-          gap: 24px;
-        }
-        .badge {
-          font-size: 12px;
-          font-weight: 600;
-          text-transform: uppercase;
-          color: #93c5fd;
-          letter-spacing: 0.08em;
-        }
-        .export-actions {
-          display: flex;
-          gap: 8px;
-          flex-wrap: wrap;
-        }
-        .info-note {
-          border-color: rgba(59, 130, 246, 0.35);
-          background: rgba(59, 130, 246, 0.08);
-        }
-        .compare-layout {
-          display: grid;
-          grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-          gap: 24px;
-          align-items: flex-start;
-        }
-        .panel {
-          background: rgba(15, 23, 42, 0.75);
+        /* ---------- Visual system inspired by the prototype ---------- */
+        .compare-shell {
           border: 1px solid var(--border-subtle);
           border-radius: 12px;
-          padding: 20px;
+          overflow: hidden;
+          background: rgba(11, 12, 15, 0.6);
+        }
+        .topbar {
+          padding: 12px 16px;
+          background: linear-gradient(180deg, #11131a, #0f1218);
+          border-bottom: 1px solid var(--border-subtle);
+          position: sticky;
+          top: 64px; /* sit below site header if present */
+          z-index: 5;
+        }
+        @media (max-width: 860px) {
+          .topbar {
+            top: 56px;
+          }
+        }
+        .bar {
           display: flex;
-          flex-direction: column;
           gap: 12px;
-        }
-        .panel-heading h3 {
-          margin: 0;
-          font-size: 16px;
-        }
-        .panel-body {
-          display: flex;
-          flex-direction: column;
-          gap: 16px;
-          max-height: 70vh;
-          overflow-y: auto;
-          padding-right: 6px;
-        }
-        .panel-body::-webkit-scrollbar {
-          width: 8px;
-        }
-        .panel-body::-webkit-scrollbar-thumb {
-          background: rgba(148, 163, 184, 0.4);
-          border-radius: 999px;
-        }
-        .section-label {
-          font-size: 12px;
-          font-weight: 600;
-          color: #94a3b8;
-          margin-bottom: 6px;
-        }
-        .section-html {
-          border: 1px solid rgba(148, 163, 184, 0.25);
-          border-radius: 10px;
-          padding: 16px;
-          background: rgba(15, 23, 42, 0.5);
-          overflow-x: auto;
-        }
-        .section-html :global(h1),
-        .section-html :global(h2),
-        .section-html :global(h3),
-        .section-html :global(h4),
-        .section-html :global(h5),
-        .section-html :global(h6) {
-          margin-top: 0;
-        }
-        .source-section,
-        .translation-section {
-          border-radius: 12px;
-          transition: border-color 0.2s ease, box-shadow 0.2s ease;
-        }
-        .source-section.active .section-html,
-        .translation-section.active .section-html {
-          border-color: rgba(59, 130, 246, 0.6);
-          box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.35);
-        }
-        .translation-section {
-          padding: 12px;
-          border: 1px solid transparent;
-        }
-        .translation-section.active {
-          border-color: rgba(59, 130, 246, 0.4);
-          background: rgba(30, 64, 175, 0.12);
-        }
-        .translation-preview {
-          background: rgba(15, 23, 42, 0.45);
-        }
-        .section-header {
-          display: flex;
-          justify-content: space-between;
           align-items: center;
-          gap: 12px;
-          margin-bottom: 8px;
+          flex-wrap: wrap;
         }
-        .section-meta {
-          display: flex;
+        .title {
+          font-weight: 700;
+          margin-right: auto;
+        }
+        .check {
+          display: inline-flex;
+          align-items: center;
           gap: 8px;
+          color: #9aa3b2;
+          border: 1px solid var(--border-subtle);
+          padding: 6px 10px;
+          border-radius: 8px;
+          background: rgba(14, 17, 24, 0.9);
+          user-select: none;
+        }
+        .check input[type='checkbox'] {
+          width: 16px;
+          height: 16px;
+          accent-color: #5b9cff;
+        }
+        .btn {
+          border: 1px solid var(--border-subtle);
+          background: rgba(14, 17, 24, 0.9);
+          color: inherit;
+          padding: 6px 10px;
+          border-radius: 8px;
+          cursor: pointer;
+        }
+        .btn.primary {
+          background: #5b9cff;
+          border-color: transparent;
+          color: #071224;
+          font-weight: 600;
+        }
+        .btn.ghost {
+          background: transparent;
+        }
+        .hint {
+          color: #9aa3b2;
+          font-size: 0.9em;
+          padding: 8px 2px 6px;
+        }
+
+        .grid {
+          display: grid;
+          grid-template-columns: 1fr 10px 1fr;
+          gap: 0;
+          min-height: 0;
+        }
+        .pane {
+          min-height: 0;
+          overflow: auto;
+          background: rgba(8, 10, 16, 0.8);
+          max-height: 72vh;
+        }
+        .pane::-webkit-scrollbar {
+          width: 10px;
+        }
+        .pane::-webkit-scrollbar-thumb {
+          background: #2a3142;
+          border-radius: 8px;
+        }
+        .paneHeader {
+          position: sticky;
+          top: 0;
+          z-index: 4;
+          padding: 10px 16px;
+          color: #9aa3b2;
+          font-weight: 600;
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          background: linear-gradient(180deg, #0b0d14, #0a0d13);
+          border-bottom: 1px solid var(--border-subtle);
+        }
+        .doc {
+          padding: 12px 18px 48px;
+        }
+        .doc h1,
+        .doc h2,
+        .doc h3 {
+          margin: 0.7em 0 0.35em;
+          line-height: 1.25;
+        }
+        .doc p {
+          margin: 0.5em 0;
+        }
+        .doc ul,
+        .doc ol {
+          margin: 0.5em 0 0.75em 1.25em;
+        }
+        .doc table {
+          border-collapse: collapse;
+          margin: 0.4em 0 1em;
+        }
+        .doc td,
+        .doc th {
+          border: 1px solid #2a3142;
+          padding: 6px 10px;
+        }
+        .doc pre {
+          background: #0e1118;
+          border: 1px solid var(--border-subtle);
+          padding: 10px;
+          border-radius: 8px;
+          overflow: auto;
+        }
+        .doc figure {
+          border: 1px solid var(--border-subtle);
+          background: #0d1017;
+          padding: 10px;
+          border-radius: 8px;
+          margin: 0.6em 0;
+        }
+        .doc figcaption {
+          color: #9aa3b2;
+          font-size: 0.9em;
+        }
+
+        /* Invisible segment wrappers + active highlight */
+        .seg {
+          margin: 0;
+          padding: 0;
+          border: 0;
+        }
+        .seg.active {
+          background: rgba(91, 156, 255, 0.14);
+          outline: 2px solid rgba(91, 156, 255, 0.55);
+          outline-offset: 2px;
+          border-radius: 8px;
+        }
+
+        .statusLine {
+          display: flex;
+          gap: 10px;
           align-items: center;
         }
         .status {
@@ -572,30 +866,31 @@ export default function TranslationDetailPage() {
         .status.error {
           color: #f87171;
         }
-        .translation-textarea {
-          width: 100%;
-          border-radius: 10px;
-          border: 1px solid rgba(148, 163, 184, 0.3);
-          padding: 12px;
-          background: rgba(15, 23, 42, 0.75);
-          color: inherit;
-          font-family: inherit;
-          font-size: 14px;
-          resize: vertical;
-          min-height: 160px;
+
+        .divider {
+          background: linear-gradient(180deg, #0a0c12, #06070b);
+          border-left: 1px solid var(--border-subtle);
+          border-right: 1px solid var(--border-subtle);
+          position: sticky;
+          top: 0;
+          cursor: col-resize;
         }
-        .translation-textarea:focus {
-          outline: none;
-          border-color: rgba(59, 130, 246, 0.8);
-          box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.35);
-        }
-        @media (max-width: 960px) {
-          .compare-header {
-            flex-direction: column;
+
+        @media (max-width: 1000px) {
+          .grid {
+            grid-template-columns: 1fr;
           }
-          .panel-body {
+          .divider {
+            display: none;
+          }
+          .pane {
             max-height: none;
           }
+        }
+
+        .info-note {
+          border-color: rgba(59, 130, 246, 0.35);
+          background: rgba(59, 130, 246, 0.08);
         }
       `}</style>
     </Layout>

--- a/frontend/admin/pages/translations/[translationId].tsx
+++ b/frontend/admin/pages/translations/[translationId].tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import Layout from '../../components/Layout';
 import {
@@ -8,44 +8,13 @@ import {
   approveTranslation,
   getTranslationDownloadUrl,
   type TranslationItem,
-  type TranslationChunk
+  type TranslationChunk,
 } from '../../lib/api';
-function stripTags(html: string) {
-  return html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
-}
 
-type DiffSegment = { kind: 'same' | 'added' | 'removed'; value: string };
-
-function computeDiff(base: string, revised: string): DiffSegment[] {
-  const baseWords = stripTags(base).split(/\s+/).filter(Boolean);
-  const revisedWords = stripTags(revised).split(/\s+/).filter(Boolean);
-  const max = Math.max(baseWords.length, revisedWords.length);
-  const segments: DiffSegment[] = [];
-  for (let i = 0; i < max; i++) {
-    const oldWord = baseWords[i];
-    const newWord = revisedWords[i];
-    if (oldWord && newWord && oldWord === newWord) {
-      segments.push({ kind: 'same', value: newWord });
-      continue;
-    }
-    if (newWord) {
-      segments.push({ kind: 'added', value: newWord });
-    }
-    if (oldWord) {
-      segments.push({ kind: 'removed', value: oldWord });
-    }
-  }
-  return segments;
-}
-
-function renderDiff(base: string, revised: string) {
-  const diff = computeDiff(base, revised);
-  return diff.map((segment, idx) => {
-    const className = segment.kind === 'added' ? 'diff-added' : segment.kind === 'removed' ? 'diff-removed' : 'diff-same';
-    const suffix = segment.kind === 'same' ? ' ' : ' ';
-    return <span key={idx} className={className}>{segment.value + suffix}</span>;
-  });
-}
+type ChunkStatus = {
+  state: 'idle' | 'saving' | 'saved' | 'error';
+  message?: string;
+};
 
 export default function TranslationDetailPage() {
   const router = useRouter();
@@ -53,83 +22,172 @@ export default function TranslationDetailPage() {
   const [translation, setTranslation] = useState<TranslationItem | null>(null);
   const [chunks, setChunks] = useState<TranslationChunk[]>([]);
   const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const draftsRef = useRef<Record<string, string>>({});
+  const chunksRef = useRef<TranslationChunk[]>([]);
+  const [chunkStatuses, setChunkStatuses] = useState<Record<string, ChunkStatus>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [savingChunk, setSavingChunk] = useState<string | null>(null);
   const [approving, setApproving] = useState(false);
   const [reviewLocked, setReviewLocked] = useState(false);
   const [chunkNotice, setChunkNotice] = useState<string | null>(null);
+  const [activeChunkId, setActiveChunkId] = useState<string | null>(null);
+  const [editingChunkId, setEditingChunkId] = useState<string | null>(null);
+  const saveTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+
+  useEffect(() => {
+    draftsRef.current = drafts;
+  }, [drafts]);
+
+  useEffect(() => {
+    chunksRef.current = chunks;
+  }, [chunks]);
 
   useEffect(() => {
     if (!translationId) return;
+    let cancelled = false;
     async function load() {
       setLoading(true);
       setReviewLocked(false);
       setChunkNotice(null);
+      setEditingChunkId(null);
+      setActiveChunkId(null);
       try {
         const t = await getTranslation(translationId);
+        if (cancelled) return;
         setTranslation(t);
         const data = await getTranslationChunks(translationId);
+        if (cancelled) return;
         setReviewLocked(Boolean(data.reviewLocked));
         setChunkNotice(data.message || null);
         const ordered = (data.chunks || []).sort((a, b) => (a.order || 0) - (b.order || 0));
         setChunks(ordered);
         if (!data.reviewLocked) {
           const nextDrafts: Record<string, string> = {};
+          const nextStatuses: Record<string, ChunkStatus> = {};
           ordered.forEach(chunk => {
             nextDrafts[chunk.id] = chunk.reviewerHtml || chunk.machineHtml || chunk.sourceHtml;
+            nextStatuses[chunk.id] = { state: 'idle' };
           });
           setDrafts(nextDrafts);
+          setChunkStatuses(nextStatuses);
+          setActiveChunkId(ordered[0]?.id ?? null);
         } else {
           setDrafts({});
+          setChunkStatuses({});
         }
       } catch (err: any) {
+        if (cancelled) return;
         if (typeof err?.message === 'string' && err.message.includes('404')) {
           setChunks([]);
           setDrafts({});
+          setChunkStatuses({});
           setChunkNotice('Chunks are not available yet.');
         } else {
-          setError(err.message || 'Failed to load translation');
+          setError(err?.message || 'Failed to load translation');
         }
       } finally {
-        setLoading(false);
+        if (!cancelled) {
+          setLoading(false);
+        }
       }
     }
     load();
+    return () => {
+      cancelled = true;
+    };
   }, [translationId]);
+
+  useEffect(() => {
+    setChunkStatuses(prev => {
+      const next: Record<string, ChunkStatus> = {};
+      let changed = false;
+      chunks.forEach(chunk => {
+        const existing = prev[chunk.id];
+        next[chunk.id] = existing || { state: 'idle' };
+        if (!existing) changed = true;
+      });
+      if (Object.keys(prev).length !== Object.keys(next).length) {
+        changed = true;
+      }
+      return changed ? next : prev;
+    });
+  }, [chunks]);
 
   const canEditChunks = useMemo(
     () => translation?.status === 'READY_FOR_REVIEW' && !reviewLocked,
     [translation, reviewLocked]
   );
   const isApproved = useMemo(() => translation?.status === 'APPROVED', [translation]);
+  const canExportTranslation = useMemo(
+    () => translation?.status === 'READY_FOR_REVIEW' || translation?.status === 'APPROVED',
+    [translation]
+  );
 
-  async function saveChunk(chunkId: string) {
-    if (!translationId) return;
-    if (!canEditChunks) {
-      setError('Translation review is read-only.');
-      return;
-    }
-    setSavingChunk(chunkId);
-    setError(null);
-    try {
-      const payload = drafts[chunkId];
-      const res = await updateTranslationChunks(translationId, [{ id: chunkId, reviewerHtml: payload }]);
-      const updatedMap: Record<string, TranslationChunk> = {};
-      (res.chunks || []).forEach(chunk => {
-        updatedMap[chunk.id] = chunk;
-      });
-      setChunks(prev => prev.map(chunk => updatedMap[chunk.id] || chunk));
-      const saved = updatedMap[chunkId];
-      if (saved) {
-        setDrafts(prev => ({ ...prev, [chunkId]: saved.reviewerHtml || saved.machineHtml || '' }));
+  const persistChunk = useCallback(
+    async (chunkId: string) => {
+      if (!translationId || !canEditChunks) return;
+      const timers = saveTimers.current;
+      if (timers[chunkId]) {
+        clearTimeout(timers[chunkId]);
+        delete timers[chunkId];
       }
-    } catch (err: any) {
-      setError(err.message || 'Save failed');
-    } finally {
-      setSavingChunk(null);
+      const payload = draftsRef.current[chunkId] ?? '';
+      const existing = chunksRef.current.find(chunk => chunk.id === chunkId);
+      const currentHtml = existing?.reviewerHtml || existing?.machineHtml || existing?.sourceHtml || '';
+      if (payload === currentHtml) {
+        setChunkStatuses(prev => ({ ...prev, [chunkId]: { state: 'saved' } }));
+        return;
+      }
+      setError(null);
+      setChunkStatuses(prev => ({ ...prev, [chunkId]: { state: 'saving' } }));
+      try {
+        const res = await updateTranslationChunks(translationId, [{ id: chunkId, reviewerHtml: payload }]);
+        const updatedMap: Record<string, TranslationChunk> = {};
+        (res.chunks || []).forEach(chunk => {
+          updatedMap[chunk.id] = chunk;
+        });
+        setChunks(prev => prev.map(chunk => updatedMap[chunk.id] || chunk));
+        const saved = updatedMap[chunkId];
+        if (saved) {
+          setDrafts(prev => ({ ...prev, [chunkId]: saved.reviewerHtml || saved.machineHtml || saved.sourceHtml || '' }));
+        }
+        setChunkStatuses(prev => ({ ...prev, [chunkId]: { state: 'saved' } }));
+      } catch (err: any) {
+        const message = err?.message || 'Save failed';
+        setError(message);
+        setChunkStatuses(prev => ({ ...prev, [chunkId]: { state: 'error', message } }));
+      }
+    },
+    [translationId, canEditChunks]
+  );
+
+  const scheduleSave = useCallback(
+    (chunkId: string) => {
+      if (!canEditChunks) return;
+      const timers = saveTimers.current;
+      if (timers[chunkId]) {
+        clearTimeout(timers[chunkId]);
+      }
+      timers[chunkId] = setTimeout(() => {
+        void persistChunk(chunkId);
+      }, 800);
+    },
+    [canEditChunks, persistChunk]
+  );
+
+  useEffect(() => {
+    return () => {
+      Object.values(saveTimers.current).forEach(timer => clearTimeout(timer));
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!canEditChunks) {
+      Object.values(saveTimers.current).forEach(timer => clearTimeout(timer));
+      saveTimers.current = {};
+      setEditingChunkId(null);
     }
-  }
+  }, [canEditChunks]);
 
   async function approve() {
     if (!translationId) return;
@@ -143,27 +201,54 @@ export default function TranslationDetailPage() {
         const chunkData = await getTranslationChunks(translationId);
         setReviewLocked(Boolean(chunkData.reviewLocked));
         setChunkNotice(chunkData.message || 'Translation has been approved.');
-        setChunks(chunkData.chunks || []);
+        const ordered = (chunkData.chunks || []).sort((a, b) => (a.order || 0) - (b.order || 0));
+        setChunks(ordered);
+        if (!chunkData.reviewLocked) {
+          const nextDrafts: Record<string, string> = {};
+          const nextStatuses: Record<string, ChunkStatus> = {};
+          ordered.forEach(chunk => {
+            nextDrafts[chunk.id] = chunk.reviewerHtml || chunk.machineHtml || chunk.sourceHtml;
+            nextStatuses[chunk.id] = { state: 'idle' };
+          });
+          setDrafts(nextDrafts);
+          setChunkStatuses(nextStatuses);
+          setActiveChunkId(ordered[0]?.id ?? null);
+        } else {
+          setDrafts({});
+          setChunkStatuses({});
+          setActiveChunkId(null);
+        }
       } catch {
         setReviewLocked(true);
         setChunkNotice('Translation has been approved. Chunk data is no longer available.');
         setChunks([]);
+        setDrafts({});
+        setChunkStatuses({});
+        setActiveChunkId(null);
       }
-      setDrafts({});
+      setEditingChunkId(null);
     } catch (err: any) {
-      setError(err.message || 'Approval failed');
+      setError(err?.message || 'Approval failed');
     } finally {
       setApproving(false);
     }
   }
 
-  async function download(type: 'original' | 'machine' | 'translated' | 'translatedHtml') {
+  type DownloadType =
+    | 'original'
+    | 'machine'
+    | 'translated'
+    | 'translatedHtml'
+    | 'translatedDocx'
+    | 'translatedPdf';
+
+  async function download(type: DownloadType) {
     if (!translationId) return;
     try {
       const { url } = await getTranslationDownloadUrl(translationId, type);
       if (url) window.open(url, '_blank');
     } catch (err: any) {
-      setError(err.message || 'Download failed');
+      setError(err?.message || 'Download failed');
     }
   }
 
@@ -188,14 +273,22 @@ export default function TranslationDetailPage() {
           <div className="row" style={{ justifyContent: 'space-between', alignItems: 'flex-start' }}>
             <div>
               <h2 style={{ marginBottom: 6 }}>{translation.title || translation.originalFilename}</h2>
-              <div className="muted">{translation.sourceLanguage?.toUpperCase()} → {translation.targetLanguage?.toUpperCase()}</div>
+              <div className="muted">
+                {translation.sourceLanguage?.toUpperCase()} → {translation.targetLanguage?.toUpperCase()}
+              </div>
               <div className="muted mini" style={{ marginTop: 4 }}>Status: {translation.status}</div>
             </div>
-            <div className="row" style={{ gap: 8 }}>
-              <button className="btn ghost mini" onClick={() => download('original')}>Original</button>
-              <button className="btn ghost mini" onClick={() => download('machine')}>Machine</button>
+            <div className="row" style={{ gap: 8, flexWrap: 'wrap' }}>
+              <button className="btn ghost mini" onClick={() => download('original')}>
+                Original
+              </button>
+              <button className="btn ghost mini" onClick={() => download('machine')}>
+                Machine
+              </button>
               {translation.status === 'APPROVED' && (
-                <button className="btn ghost mini" onClick={() => download('translated')}>Final</button>
+                <button className="btn ghost mini" onClick={() => download('translated')}>
+                  Final HTML
+                </button>
               )}
               {translation.status === 'READY_FOR_REVIEW' && (
                 <button className="btn" onClick={approve} disabled={approving || reviewLocked}>
@@ -214,63 +307,131 @@ export default function TranslationDetailPage() {
             {chunkNotice && <div className="muted mini" style={{ marginTop: 8 }}>{chunkNotice}</div>}
           </div>
         ) : (
-          <div className="stack" style={{ gap: 24 }}>
+          <>
+            <div className="card compare-header">
+              <div>
+                <div className="badge">Document Compare — Source ↔ Translation</div>
+                <div className="muted mini" style={{ marginTop: 4 }}>
+                  Click anywhere in the Translation panel to edit that section. Matching source content highlights automatically.
+                </div>
+                <div className="muted mini" style={{ marginTop: 4 }}>
+                  Changes are autosaved as one continuous document.
+                </div>
+              </div>
+              {canExportTranslation && (
+                <div className="export-actions">
+                  <button className="btn" onClick={() => download('translatedDocx')}>
+                    Export DOCX
+                  </button>
+                  <button className="btn ghost" onClick={() => download('translatedPdf')}>
+                    Export PDF
+                  </button>
+                </div>
+              )}
+            </div>
             {chunkNotice && (
-              <div className="card" style={{ background: 'rgba(59,130,246,.08)', borderColor: 'rgba(59,130,246,.35)' }}>
+              <div className="card info-note">
                 <div className="muted mini">{chunkNotice}</div>
               </div>
             )}
-            {chunks.map(chunk => {
-              const draft = drafts[chunk.id];
-              const machineHtml = chunk.machineHtml || '';
-              return (
-                <div key={chunk.id} className="card">
-                  <div className="row" style={{ justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
-                    <div style={{ fontWeight: 600 }}>Chunk {chunk.order}</div>
-                    <button
-                      className="btn ghost mini"
-                      onClick={() => saveChunk(chunk.id)}
-                      disabled={savingChunk === chunk.id || !canEditChunks}
+            <div className="compare-layout">
+              <section className="panel source-panel">
+                <header className="panel-heading">
+                  <div>
+                    <h3>Source (read-only)</h3>
+                    <p className="muted mini">Use this for context while you revise.</p>
+                  </div>
+                </header>
+                <div className="panel-body">
+                  {chunks.map(chunk => (
+                    <article
+                      key={chunk.id}
+                      className={`source-section ${activeChunkId === chunk.id ? 'active' : ''}`}
+                      onClick={() => setActiveChunkId(chunk.id)}
                     >
-                      {savingChunk === chunk.id ? 'Saving…' : 'Save chunk'}
-                    </button>
-                  </div>
-                  <div className="grid cols-3" style={{ gap: 16 }}>
-                    <div>
-                      <h4 className="muted" style={{ marginBottom: 6 }}>Source</h4>
-                      <div className="preview" dangerouslySetInnerHTML={{ __html: chunk.sourceHtml }} />
-                    </div>
-                    <div>
-                      <h4 className="muted" style={{ marginBottom: 6 }}>Translation (HTML)</h4>
-                      <textarea
-                        className="textarea"
-                        rows={8}
-                        value={draft}
-                        onChange={e => setDrafts(prev => ({ ...prev, [chunk.id]: e.target.value }))}
-                        disabled={!canEditChunks}
-                      />
-                      <div className="muted mini" style={{ marginTop: 4 }}>Keep HTML tags intact.</div>
-                    </div>
-                    <div>
-                      <h4 className="muted" style={{ marginBottom: 6 }}>Preview</h4>
-                      <div className="preview" dangerouslySetInnerHTML={{ __html: draft }} />
-                    </div>
-                  </div>
-                  <div style={{ marginTop: 12 }}>
-                    <h4 className="muted" style={{ marginBottom: 6 }}>Changes vs machine translation</h4>
-                    <div className="diff-view">
-                      {renderDiff(machineHtml, draft)}
-                    </div>
-                  </div>
+                      <div className="section-label">Section {chunk.order}</div>
+                      <div className="section-html" dangerouslySetInnerHTML={{ __html: chunk.sourceHtml }} />
+                    </article>
+                  ))}
+                  {!chunks.length && <div className="muted mini">No sections available yet.</div>}
                 </div>
-              );
-            })}
-            {!chunks.length && (
-              <div className="card">
-                <div className="muted">No chunks available yet.</div>
-              </div>
-            )}
-          </div>
+              </section>
+              <section className="panel translation-panel">
+                <header className="panel-heading">
+                  <div>
+                    <h3>Translation</h3>
+                    <p className="muted mini">Select a section to revise the translation. Keep HTML structure intact when editing.</p>
+                  </div>
+                </header>
+                <div className="panel-body">
+                  {chunks.map(chunk => {
+                    const draft = drafts[chunk.id] ?? '';
+                    const status = chunkStatuses[chunk.id] || { state: 'idle' };
+                    const isEditing = editingChunkId === chunk.id;
+                    const translationHtml = draft || '';
+                    return (
+                      <article
+                        key={chunk.id}
+                        className={`translation-section ${activeChunkId === chunk.id ? 'active' : ''}`}
+                        onClick={() => setActiveChunkId(chunk.id)}
+                      >
+                        <div className="section-header">
+                          <div className="section-label">Section {chunk.order}</div>
+                          <div className="section-meta">
+                            {status.state === 'saving' && <span className="status saving">Saving…</span>}
+                            {status.state === 'saved' && <span className="status saved">Autosaved</span>}
+                            {status.state === 'error' && <span className="status error">{status.message || 'Autosave failed'}</span>}
+                            <button
+                              className="btn ghost mini"
+                              disabled={!canEditChunks}
+                              onClick={e => {
+                                e.stopPropagation();
+                                if (isEditing) {
+                                  setEditingChunkId(null);
+                                  void persistChunk(chunk.id);
+                                } else {
+                                  setEditingChunkId(chunk.id);
+                                  setActiveChunkId(chunk.id);
+                                }
+                              }}
+                            >
+                              {isEditing ? 'Done' : 'Edit'}
+                            </button>
+                          </div>
+                        </div>
+                        {isEditing ? (
+                          <textarea
+                            className="translation-textarea"
+                            value={draft}
+                            onChange={e => {
+                              const value = e.target.value;
+                              setDrafts(prev => ({ ...prev, [chunk.id]: value }));
+                              setChunkStatuses(prev => ({ ...prev, [chunk.id]: { state: 'saving' } }));
+                              scheduleSave(chunk.id);
+                            }}
+                            onFocus={() => setActiveChunkId(chunk.id)}
+                            onBlur={() => {
+                              void persistChunk(chunk.id);
+                            }}
+                            rows={Math.max(8, Math.ceil(Math.max(draft.length, 1) / 120))}
+                            disabled={!canEditChunks}
+                          />
+                        ) : (
+                          <div className="section-html translation-preview" dangerouslySetInnerHTML={{ __html: translationHtml }} />
+                        )}
+                        {!isEditing && (
+                          <div className="muted mini" style={{ marginTop: 8 }}>
+                            Click Edit to revise this section. Changes are saved automatically.
+                          </div>
+                        )}
+                      </article>
+                    );
+                  })}
+                  {!chunks.length && <div className="muted mini">No translated sections yet.</div>}
+                </div>
+              </section>
+            </div>
+          </>
         )
       ) : isApproved ? (
         <div className="card">
@@ -289,34 +450,152 @@ export default function TranslationDetailPage() {
       )}
 
       <style jsx>{`
-        .preview {
+        .compare-header {
+          display: flex;
+          align-items: flex-start;
+          justify-content: space-between;
+          gap: 24px;
+        }
+        .badge {
+          font-size: 12px;
+          font-weight: 600;
+          text-transform: uppercase;
+          color: #93c5fd;
+          letter-spacing: 0.08em;
+        }
+        .export-actions {
+          display: flex;
+          gap: 8px;
+          flex-wrap: wrap;
+        }
+        .info-note {
+          border-color: rgba(59, 130, 246, 0.35);
+          background: rgba(59, 130, 246, 0.08);
+        }
+        .compare-layout {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+          gap: 24px;
+          align-items: flex-start;
+        }
+        .panel {
+          background: rgba(15, 23, 42, 0.75);
           border: 1px solid var(--border-subtle);
-          border-radius: 8px;
-          padding: 12px;
-          background: #fff;
-          min-height: 120px;
+          border-radius: 12px;
+          padding: 20px;
+          display: flex;
+          flex-direction: column;
+          gap: 12px;
+        }
+        .panel-heading h3 {
+          margin: 0;
+          font-size: 16px;
+        }
+        .panel-body {
+          display: flex;
+          flex-direction: column;
+          gap: 16px;
+          max-height: 70vh;
+          overflow-y: auto;
+          padding-right: 6px;
+        }
+        .panel-body::-webkit-scrollbar {
+          width: 8px;
+        }
+        .panel-body::-webkit-scrollbar-thumb {
+          background: rgba(148, 163, 184, 0.4);
+          border-radius: 999px;
+        }
+        .section-label {
+          font-size: 12px;
+          font-weight: 600;
+          color: #94a3b8;
+          margin-bottom: 6px;
+        }
+        .section-html {
+          border: 1px solid rgba(148, 163, 184, 0.25);
+          border-radius: 10px;
+          padding: 16px;
+          background: rgba(15, 23, 42, 0.5);
           overflow-x: auto;
         }
-        .diff-view {
-          border: 1px dashed var(--border-subtle);
-          padding: 8px;
-          border-radius: 6px;
-          font-family: monospace;
-          white-space: pre-wrap;
+        .section-html :global(h1),
+        .section-html :global(h2),
+        .section-html :global(h3),
+        .section-html :global(h4),
+        .section-html :global(h5),
+        .section-html :global(h6) {
+          margin-top: 0;
         }
-        .diff-added {
-          background: rgba(16, 185, 129, 0.18);
-          border-radius: 4px;
-          padding: 0 2px;
+        .source-section,
+        .translation-section {
+          border-radius: 12px;
+          transition: border-color 0.2s ease, box-shadow 0.2s ease;
         }
-        .diff-removed {
-          background: rgba(239, 68, 68, 0.18);
-          border-radius: 4px;
-          padding: 0 2px;
-          text-decoration: line-through;
+        .source-section.active .section-html,
+        .translation-section.active .section-html {
+          border-color: rgba(59, 130, 246, 0.6);
+          box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.35);
         }
-        .diff-same {
-          opacity: 0.7;
+        .translation-section {
+          padding: 12px;
+          border: 1px solid transparent;
+        }
+        .translation-section.active {
+          border-color: rgba(59, 130, 246, 0.4);
+          background: rgba(30, 64, 175, 0.12);
+        }
+        .translation-preview {
+          background: rgba(15, 23, 42, 0.45);
+        }
+        .section-header {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          gap: 12px;
+          margin-bottom: 8px;
+        }
+        .section-meta {
+          display: flex;
+          gap: 8px;
+          align-items: center;
+        }
+        .status {
+          font-size: 12px;
+        }
+        .status.saving {
+          color: #fbbf24;
+        }
+        .status.saved {
+          color: #34d399;
+        }
+        .status.error {
+          color: #f87171;
+        }
+        .translation-textarea {
+          width: 100%;
+          border-radius: 10px;
+          border: 1px solid rgba(148, 163, 184, 0.3);
+          padding: 12px;
+          background: rgba(15, 23, 42, 0.75);
+          color: inherit;
+          font-family: inherit;
+          font-size: 14px;
+          resize: vertical;
+          min-height: 160px;
+        }
+        .translation-textarea:focus {
+          outline: none;
+          border-color: rgba(59, 130, 246, 0.8);
+          box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.35);
+        }
+        @media (max-width: 960px) {
+          .compare-header {
+            flex-direction: column;
+          }
+          .panel-body {
+            max-height: none;
+          }
         }
       `}</style>
     </Layout>


### PR DESCRIPTION
## Summary
- redesign the translation review detail view around a side-by-side compare layout with inline editing, autosave cues, and active section highlighting
- add export controls for DOCX/PDF downloads and extend the client API to request the new formats

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d84f267c3c83319c194d2bd15d1cca