### PR TITLE
Add pause and cancellation controls for translations

### DIFF
--- a/frontend/admin/pages/translations/[translationId].tsx
+++ b/frontend/admin/pages/translations/[translationId].tsx
@@ -66,6 +66,10 @@ export default function TranslationDetailPage() {
     [translation, reviewLocked]
   );
   const isApproved = useMemo(() => translation?.status === 'APPROVED', [translation]);
+  const isPaused = useMemo(() => translation?.status === 'PAUSED', [translation]);
+  const pausePending = useMemo(() => translation?.status === 'PAUSE_REQUESTED', [translation]);
+  const cancelPending = useMemo(() => translation?.status === 'CANCEL_REQUESTED', [translation]);
+  const isCancelled = useMemo(() => translation?.status === 'CANCELLED', [translation]);
   const canExportTranslation = useMemo(
     () => translation?.status === 'READY_FOR_REVIEW' || translation?.status === 'APPROVED',
     [translation]
@@ -554,6 +558,27 @@ export default function TranslationDetailPage() {
               )}
             </div>
           </div>
+        </div>
+      )}
+
+      {pausePending && (
+        <div className="card info-note" style={{ marginBottom: 16 }}>
+          <div className="muted mini">Pause requested. The translation worker will pause shortly.</div>
+        </div>
+      )}
+      {isPaused && (
+        <div className="card info-note" style={{ marginBottom: 16 }}>
+          <div className="muted mini">Translation is paused. Resume from the overview to continue processing.</div>
+        </div>
+      )}
+      {cancelPending && (
+        <div className="card info-note" style={{ marginBottom: 16 }}>
+          <div className="muted mini">Cancellation requested. Remaining work will stop soon.</div>
+        </div>
+      )}
+      {isCancelled && (
+        <div className="card" style={{ marginBottom: 16, borderColor: 'rgba(220,38,38,0.4)', background: 'rgba(220,38,38,0.05)' }}>
+          <div className="muted mini" style={{ color: '#dc2626' }}>Translation was cancelled. No further processing will occur.</div>
         </div>
       )}
 

--- a/frontend/admin/pages/users.tsx
+++ b/frontend/admin/pages/users.tsx
@@ -3,9 +3,11 @@ import Layout from '../components/Layout';
 import { getUsers, inviteUser, activateUser, deactivateUser, deleteUser, updateUserNotificationPreferences, type User, type NotificationPreferences } from '../lib/api';
 
 const DEFAULT_NOTIFICATION_PREFS: NotificationPreferences = {
-  translation: { started: false, completed: true, failed: true },
+  translation: { started: false, completed: true, failed: true, paused: false, resumed: false, cancelled: false },
   documentation: { started: false, completed: true, failed: true }
 };
+
+const TRANSLATION_PREF_KEYS: Array<keyof NotificationPreferences['translation']> = ['started', 'completed', 'failed', 'paused', 'resumed', 'cancelled'];
 
 export default function Users() {
   const [users, setUsers] = useState<User[]>([]);
@@ -155,10 +157,10 @@ export default function Users() {
   }
 
   function getUserPreferences(user: User): NotificationPreferences {
-    const base = user.notifications?.preferences || DEFAULT_NOTIFICATION_PREFS;
+    const base = user.notifications?.preferences || {};
     return {
-      translation: { ...base.translation },
-      documentation: { ...base.documentation }
+      translation: { ...DEFAULT_NOTIFICATION_PREFS.translation, ...(base.translation || {}) },
+      documentation: { ...DEFAULT_NOTIFICATION_PREFS.documentation, ...(base.documentation || {}) }
     };
   }
 
@@ -269,8 +271,8 @@ export default function Users() {
                       <td style={{ padding: '12px 8px', fontSize: '12px', color: '#444' }}>
                         <div style={{ marginBottom: 6 }}>
                           <strong>Translation</strong>
-                          <div style={{ display: 'flex', gap: 12, marginTop: 4 }}>
-                            {(['started', 'completed', 'failed'] as Array<keyof NotificationPreferences['translation']>).map((status) => (
+                          <div style={{ display: 'flex', gap: 12, marginTop: 4, flexWrap: 'wrap' }}>
+                            {TRANSLATION_PREF_KEYS.map((status) => (
                               <label key={status} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
                                 <input
                                   type="checkbox"

--- a/sam/resources.yaml
+++ b/sam/resources.yaml
@@ -524,6 +524,24 @@ Resources:
             RestApiId: !Ref Api
             Path: /translations/{translationId}
             Method: DELETE
+        PauseTranslation:
+          Type: Api
+          Properties:
+            RestApiId: !Ref Api
+            Path: /translations/{translationId}/pause
+            Method: POST
+        ResumeTranslation:
+          Type: Api
+          Properties:
+            RestApiId: !Ref Api
+            Path: /translations/{translationId}/resume
+            Method: POST
+        CancelTranslation:
+          Type: Api
+          Properties:
+            RestApiId: !Ref Api
+            Path: /translations/{translationId}/stop
+            Method: POST
         RestartTranslation:
           Type: Api
           Properties:

--- a/src/handlers/helpers/notifications.js
+++ b/src/handlers/helpers/notifications.js
@@ -15,18 +15,17 @@ function now() {
 
 function normalisePreferences(input = {}) {
   const defaults = {
-    translation: { started: false, completed: true, failed: true },
+    translation: { started: false, completed: true, failed: true, paused: false, resumed: false, cancelled: false },
     documentation: { started: false, completed: true, failed: true }
   };
   const out = {};
   for (const jobType of Object.keys(defaults)) {
     const base = defaults[jobType];
     const provided = input[jobType] || {};
-    out[jobType] = {
-      started: Boolean(provided.started ?? base.started),
-      completed: Boolean(provided.completed ?? base.completed),
-      failed: Boolean(provided.failed ?? base.failed)
-    };
+    out[jobType] = {};
+    for (const [key, value] of Object.entries(base)) {
+      out[jobType][key] = Boolean(provided[key] ?? value);
+    }
   }
   return out;
 }

--- a/src/handlers/translations.js
+++ b/src/handlers/translations.js
@@ -70,6 +70,11 @@ function actorFrom(reviewer, role = 'user') {
   };
 }
 
+function actorLabel(actor) {
+  if (!actor) return null;
+  return actor.email || actor.name || actor.sub || actor.role || actor.type || null;
+}
+
 async function recordLog(entry) {
   try {
     await appendJobLog({
@@ -672,12 +677,135 @@ exports.handler = async (event, context, callback) => {
     
     console.log('extracted translationId', { translationId });
 
+    if (method === 'POST' && path.endsWith('/pause')) {
+      const item = await getTranslation(translationId, ownerId);
+      if (!item) {
+        return ok(404, { message: 'Translation not found' }, callback);
+      }
+      if (item.status === 'PAUSED') {
+        return ok(200, { message: 'Translation already paused', status: item.status }, callback);
+      }
+      if (item.status === 'PAUSE_REQUESTED') {
+        return ok(202, { message: 'Pause request already in progress' }, callback);
+      }
+      if (item.status !== 'PROCESSING') {
+        return ok(409, { message: 'Translation cannot be paused from the current state' }, callback);
+      }
+      const actor = actorFrom(reviewer, 'admin');
+      const patch = {
+        status: 'PAUSE_REQUESTED',
+        pauseRequestedAt: now(),
+        pauseRequestedBy: actorLabel(actor),
+        pauseRequestedByEmail: actor.email || null,
+        pauseRequestedBySub: actor.sub || null
+      };
+      await updateTranslation(translationId, ownerId, patch);
+      await recordLog({
+        translationId,
+        ownerId,
+        category: 'processing-control',
+        stage: 'pause',
+        eventType: 'pause-requested',
+        status: 'PAUSE_REQUESTED',
+        message: 'Pause requested by administrator',
+        actor
+      });
+      return ok(202, { message: 'Pause requested' }, callback);
+    }
+
+    if (method === 'POST' && path.endsWith('/resume')) {
+      const item = await getTranslation(translationId, ownerId);
+      if (!item) {
+        return ok(404, { message: 'Translation not found' }, callback);
+      }
+      if (!['PAUSED', 'PAUSE_REQUESTED'].includes(item.status)) {
+        return ok(409, { message: 'Translation cannot be resumed from the current state' }, callback);
+      }
+      const actor = actorFrom(reviewer, 'admin');
+      const patch = {
+        status: 'PROCESSING',
+        resumedAt: now(),
+        resumedBy: actorLabel(actor),
+        resumedByEmail: actor.email || null,
+        resumedBySub: actor.sub || null,
+        pauseRequestedAt: null,
+        pauseRequestedBy: null,
+        pauseRequestedByEmail: null,
+        pauseRequestedBySub: null,
+        pausedAt: null,
+        pausedBy: null,
+        pausedByEmail: null,
+        pausedBySub: null,
+        healthCheckRetries: 0,
+        healthCheckReason: null
+      };
+      await updateTranslation(translationId, ownerId, patch);
+      await recordLog({
+        translationId,
+        ownerId,
+        category: 'processing-control',
+        stage: 'resume',
+        eventType: 'resume-requested',
+        status: 'PROCESSING',
+        message: 'Resume requested by administrator',
+        actor
+      });
+      await publishTranslationRestart(translationId, ownerId);
+      await sendJobNotification({
+        jobType: 'translation',
+        status: 'resumed',
+        fileName: item.originalFilename || item.title || item.translationId,
+        jobId: translationId,
+        ownerId
+      });
+      return ok(202, { message: 'Resume requested' }, callback);
+    }
+
+    if (method === 'POST' && (path.endsWith('/stop') || path.endsWith('/cancel'))) {
+      const item = await getTranslation(translationId, ownerId);
+      if (!item) {
+        return ok(404, { message: 'Translation not found' }, callback);
+      }
+      if (item.status === 'CANCELLED') {
+        return ok(200, { message: 'Translation already cancelled' }, callback);
+      }
+      if (item.status === 'CANCEL_REQUESTED') {
+        return ok(202, { message: 'Cancellation already requested' }, callback);
+      }
+      if (!['PROCESSING', 'PAUSE_REQUESTED', 'PAUSED'].includes(item.status)) {
+        return ok(409, { message: 'Translation cannot be cancelled from the current state' }, callback);
+      }
+      const actor = actorFrom(reviewer, 'admin');
+      const body = parseBody(event);
+      const patch = {
+        status: 'CANCEL_REQUESTED',
+        cancelRequestedAt: now(),
+        cancelRequestedBy: actorLabel(actor),
+        cancelRequestedByEmail: actor.email || null,
+        cancelRequestedBySub: actor.sub || null,
+        cancelReason: body?.reason || null
+      };
+      await updateTranslation(translationId, ownerId, patch);
+      await recordLog({
+        translationId,
+        ownerId,
+        category: 'processing-control',
+        stage: 'cancel',
+        eventType: 'cancel-requested',
+        status: 'CANCEL_REQUESTED',
+        message: body?.reason ? `Cancellation requested: ${body.reason}` : 'Cancellation requested by administrator',
+        actor
+      });
+      await publishTranslationRestart(translationId, ownerId);
+      return ok(202, { message: 'Cancellation requested' }, callback);
+    }
+
     if (method === 'POST' && path.endsWith('/restart')) {
       const item = await getTranslation(translationId, ownerId);
       if (!item) {
         return ok(404, { message: 'Translation not found' }, callback);
       }
-      if (!['FAILED', 'PROCESSING'].includes(item.status)) {
+      if (!['FAILED', 'PROCESSING', 'CANCELLED'].includes(item.status)) {
         return ok(409, { message: 'Translation cannot be restarted from the current state' }, callback);
       }
       await updateTranslation(translationId, ownerId, {
@@ -686,7 +814,12 @@ exports.handler = async (event, context, callback) => {
         errorContext: null,
         restartedAt: now(),
         healthCheckRetries: 0,
-        healthCheckReason: null
+        healthCheckReason: null,
+        cancelRequestedAt: null,
+        cancelRequestedBy: null,
+        cancelRequestedByEmail: null,
+        cancelRequestedBySub: null,
+        cancelReason: null
       });
       await recordLog({
         translationId,


### PR DESCRIPTION
## Summary
- add pause, resume, and stop endpoints plus lifecycle logging for translations so operators can control in-flight jobs
- teach the translation worker and health monitor to honour pause/cancel signals, clean up cancelled artefacts, and emit notifications
- expose new control buttons, status badges, and notification toggles in the admin UI and API client

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68db14624fd48331839d31e241300a9d