### PR TITLE
Refactor translation worker to use SQS fan-out

### DIFF
--- a/sam/resources.yaml
+++ b/sam/resources.yaml
@@ -437,6 +437,7 @@ Resources:
           TRANSLATION_MODEL: gpt-4o-mini
           SETTINGS_TABLE: !ImportValue { 'Fn::Sub': '${ProjectName}-${Stage}-SettingsTableName' }
           SES_SENDER: !Ref SesSenderEmail
+          TRANSLATION_QUEUE_URL: !Ref TranslationWorkerQueue
       Policies:
         - Statement:
             - Effect: Allow
@@ -455,8 +456,9 @@ Resources:
         - Statement:
             - Effect: Allow
               Action:
-                - events:PutEvents
-              Resource: '*'
+                - sqs:SendMessage
+                - sqs:SendMessageBatch
+              Resource: !GetAtt TranslationWorkerQueue.Arn
         - Statement:
             - Effect: Allow
               Action:
@@ -543,6 +545,12 @@ Resources:
             Path: /translations/{translationId}/logs
             Method: OPTIONS
 
+  TranslationWorkerQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub "${ProjectName}-${Stage}-translation-worker"
+      VisibilityTimeout: 300
+
   TranslationWorkerFn:
     Type: AWS::Serverless::Function
     Properties:
@@ -559,6 +567,7 @@ Resources:
           TRANSLATION_MODEL: gpt-4o-mini
           SETTINGS_TABLE: !ImportValue { 'Fn::Sub': '${ProjectName}-${Stage}-SettingsTableName' }
           SES_SENDER: !Ref SesSenderEmail
+          TRANSLATION_QUEUE_URL: !Ref TranslationWorkerQueue
       Policies:
         - Statement:
             - Effect: Allow
@@ -570,6 +579,12 @@ Resources:
               Action:
                 - s3:*
               Resource: '*'
+        - Statement:
+            - Effect: Allow
+              Action:
+                - sqs:SendMessage
+                - sqs:SendMessageBatch
+              Resource: !GetAtt TranslationWorkerQueue.Arn
         - Statement:
             - Effect: Allow
               Action:
@@ -586,25 +601,13 @@ Resources:
                 - ses:SendEmail
                 - ses:SendRawEmail
               Resource: '*'
-
-  TranslationEventRule:
-    Type: AWS::Events::Rule
-    Properties:
-      Name: !Sub "${ProjectName}-${Stage}-translation-requested"
-      EventPattern:
-        source: ["ops-agent"]
-        detail-type: ["TranslationRequested"]
-      Targets:
-        - Arn: !GetAtt TranslationWorkerFn.Arn
-          Id: TranslationWorkerTarget
-
-  TranslationWorkerPermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      Action: lambda:InvokeFunction
-      FunctionName: !Ref TranslationWorkerFn
-      Principal: events.amazonaws.com
-      SourceArn: !GetAtt TranslationEventRule.Arn
+      Events:
+        TranslationQueue:
+          Type: SQS
+          Properties:
+            Queue: !GetAtt TranslationWorkerQueue.Arn
+            BatchSize: 5
+            Enabled: true
 
   JobHealthCheckFn:
     Type: AWS::Serverless::Function
@@ -622,6 +625,7 @@ Resources:
           INGEST_WORKER_FUNCTION_NAME: !Sub "${ProjectName}-${Stage}-ingest-worker"
           JOB_HEALTH_STALE_MINUTES: '15'
           JOB_HEALTH_MAX_RETRIES: '3'
+          TRANSLATION_QUEUE_URL: !Ref TranslationWorkerQueue
       Policies:
         - Statement:
             - Effect: Allow
@@ -631,8 +635,9 @@ Resources:
         - Statement:
             - Effect: Allow
               Action:
-                - events:PutEvents
-              Resource: '*'
+                - sqs:SendMessage
+                - sqs:SendMessageBatch
+              Resource: !GetAtt TranslationWorkerQueue.Arn
         - Statement:
             - Effect: Allow
               Action:

--- a/src/handlers/helpers/translationWorkerModes.js
+++ b/src/handlers/helpers/translationWorkerModes.js
@@ -1,0 +1,657 @@
+const { prepareTranslationDocument, assembleHtmlDocument } = require('./documentParser');
+const { persistAssetsAndAnchors } = require('./assetStore');
+const { getTranslationEngine } = require('./translationEngine');
+const {
+  ensureChunkSource,
+  listChunks,
+  updateChunkState,
+  summariseChunks,
+  getChunk
+} = require('./translationStore');
+
+function chunkMessagePayload({ translationId, ownerId, chunk }) {
+  return {
+    action: 'process-chunk',
+    translationId,
+    ownerId,
+    chunkOrder: chunk.order,
+    chunkId: chunk.chunkId
+  };
+}
+
+function safeJsonParse(buffer) {
+  try {
+    return JSON.parse(buffer.toString('utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+function createModeHandlers(deps) {
+  const {
+    RAW_BUCKET,
+    queueUrl,
+    now,
+    readObject,
+    putObject,
+    failTranslation,
+    getTranslationItem,
+    updateTranslationItem,
+    recordLog,
+    sendQueueMessage,
+    sendQueueBatch,
+    sendJobNotification
+  } = deps;
+
+  async function orchestrate(payload) {
+    const translationId = payload?.translationId;
+    const ownerId = payload?.ownerId || 'default';
+    if (!translationId) {
+      console.warn('orchestrate invoked without translationId', { payload });
+      return;
+    }
+
+    if (!RAW_BUCKET || !queueUrl) {
+      await failTranslation({
+        translationId,
+        ownerId,
+        errorMessage: !RAW_BUCKET ? 'RAW_BUCKET not configured' : 'TRANSLATION queue not configured'
+      });
+      return;
+    }
+
+    let item;
+    try {
+      item = await getTranslationItem(translationId, ownerId);
+    } catch (err) {
+      await failTranslation({ translationId, ownerId, errorMessage: err.message });
+      return;
+    }
+
+    const attempt = Number(item.healthCheckRetries || 0) + 1;
+    const originalKey = item.originalFileKey;
+    if (!originalKey) {
+      await failTranslation({
+        translationId,
+        ownerId,
+        errorMessage: 'Original file key missing on translation item',
+        context: item,
+        fileName: item?.originalFilename,
+        attempt
+      });
+      return;
+    }
+
+    const startedAt = item.startedAt || now();
+    await updateTranslationItem(translationId, ownerId, { status: 'PROCESSING', startedAt });
+    await recordLog({
+      translationId,
+      ownerId,
+      category: 'processing-kickoff',
+      stage: 'start',
+      eventType: 'processing-started',
+      status: 'PROCESSING',
+      message: 'Translation processing started',
+      metadata: { startedAt },
+      attempt
+    });
+
+    let buffer;
+    let contentType;
+    try {
+      ({ buffer, contentType } = await readObject(RAW_BUCKET, originalKey));
+    } catch (readErr) {
+      await failTranslation({
+        translationId,
+        ownerId,
+        errorMessage: 'Failed to read source document from S3',
+        context: { originalKey, error: readErr.message },
+        fileName: item.originalFilename,
+        attempt
+      });
+      return;
+    }
+
+    let document;
+    try {
+      document = await prepareTranslationDocument({
+        buffer,
+        contentType,
+        filename: item.originalFilename || originalKey.split('/').pop() || 'document'
+      });
+    } catch (parseErr) {
+      await recordLog({
+        translationId,
+        ownerId,
+        eventType: 'parsing-error',
+        status: 'FAILED',
+        message: `Document parsing failed: ${parseErr.message}`,
+        metadata: {
+          filename: item.originalFilename,
+          contentType,
+          errorType: parseErr.name || 'ParseError'
+        },
+        context: {
+          parseError: parseErr.message,
+          filename: item.originalFilename || originalKey.split('/').pop() || 'document',
+          stackTrace: parseErr.stack
+        },
+        attempt
+      });
+
+      await failTranslation({
+        translationId,
+        ownerId,
+        errorMessage: 'Failed to prepare translation document',
+        context: { error: parseErr.message },
+        fileName: item.originalFilename,
+        attempt
+      });
+      return;
+    }
+
+    await recordLog({
+      translationId,
+      ownerId,
+      category: 'processing-kickoff',
+      stage: 'document-parse',
+      eventType: 'document-parsed',
+      status: 'PROCESSING',
+      message: 'Source document parsed for translation',
+      metadata: {
+        contentType,
+        chunkEstimate: Array.isArray(document?.chunks) ? document.chunks.length : 0,
+        assetCount: Array.isArray(document?.assets) ? document.assets.length : 0
+      },
+      attempt
+    });
+
+    let assetContext = { assets: [], anchors: [] };
+    let enrichedAssets = document.assets || [];
+    let resolvedAnchors = document.anchors || [];
+    try {
+      assetContext = await persistAssetsAndAnchors({
+        s3: deps.s3,
+        ddb: deps.ddb,
+        bucket: RAW_BUCKET,
+        tableName: deps.DOCS_TABLE,
+        translationId,
+        ownerId,
+        assets: document.assets || [],
+        anchors: document.anchors || []
+      });
+      if (assetContext?.assets?.length) {
+        const assetMap = new Map(assetContext.assets.map(asset => [asset.assetId, asset]));
+        enrichedAssets = (document.assets || []).map(asset => {
+          const stored = assetMap.get(asset.assetId);
+          if (!stored) return asset;
+          return { ...asset, s3Bucket: stored.s3Bucket || null, s3Key: stored.s3Key || null };
+        });
+      }
+      if (assetContext?.anchors?.length) {
+        resolvedAnchors = assetContext.anchors;
+      }
+    } catch (assetErr) {
+      await failTranslation({
+        translationId,
+        ownerId,
+        errorMessage: 'Failed to persist asset metadata',
+        context: { error: assetErr.message },
+        fileName: item.originalFilename,
+        attempt
+      });
+      return;
+    }
+
+    await recordLog({
+      translationId,
+      ownerId,
+      category: 'processing',
+      stage: 'asset-preparation',
+      eventType: 'assets-indexed',
+      status: 'PROCESSING',
+      message: 'Assets and anchors prepared for translation',
+      metadata: {
+        assetsStored: assetContext?.assets?.length || enrichedAssets.length || 0,
+        anchorsStored: assetContext?.anchors?.length || resolvedAnchors.length || 0
+      },
+      attempt
+    });
+
+    const existingChunks = await listChunks(translationId, ownerId);
+    const byId = new Map();
+    for (const stored of existingChunks) {
+      if (stored?.chunkId) {
+        byId.set(stored.chunkId, stored);
+      }
+    }
+
+    const pending = [];
+    for (const chunk of document.chunks) {
+      const stored = await ensureChunkSource({ translationId, ownerId, chunk });
+      const record = stored || byId.get(chunk.id) || null;
+      if (record?.chunkId) {
+        byId.set(record.chunkId, record);
+        if (record.status !== 'COMPLETED') {
+          pending.push(record);
+        }
+      }
+    }
+
+    const chunkSummary = summariseChunks(Array.from(byId.values()));
+    const contextKey = `translations/work/${ownerId}/${translationId}/context.json`;
+    try {
+      await putObject(RAW_BUCKET, contextKey, JSON.stringify({
+        headHtml: document.headHtml,
+        assets: enrichedAssets,
+        anchors: resolvedAnchors
+      }), 'application/json');
+    } catch (storeErr) {
+      await failTranslation({
+        translationId,
+        ownerId,
+        errorMessage: 'Failed to persist translation context',
+        context: { contextKey, error: storeErr.message },
+        fileName: item.originalFilename,
+        attempt
+      });
+      return;
+    }
+
+    await updateTranslationItem(translationId, ownerId, {
+      totalChunks: document.chunks.length,
+      processedChunks: chunkSummary.completed,
+      failedChunks: chunkSummary.failed,
+      headHtml: document.headHtml,
+      assetCount: enrichedAssets.length,
+      documentContextKey: contextKey
+    });
+
+    await recordLog({
+      translationId,
+      ownerId,
+      category: 'chunk-processing',
+      stage: 'queue',
+      eventType: 'chunks-queued',
+      status: 'PROCESSING',
+      message: `${pending.length} chunk(s) queued for machine translation`,
+      metadata: {
+        totalChunks: document.chunks.length,
+        pendingChunks: pending.length,
+        completedChunks: chunkSummary.completed
+      },
+      chunkProgress: {
+        completed: chunkSummary.completed,
+        failed: chunkSummary.failed,
+        total: document.chunks.length
+      },
+      attempt
+    });
+
+    if (pending.length) {
+      const messages = pending.map(chunk => chunkMessagePayload({ translationId, ownerId, chunk }));
+      await sendQueueBatch(messages);
+    } else if (chunkSummary.total > 0 && chunkSummary.completed === chunkSummary.total) {
+      await sendQueueMessage({ action: 'assemble', translationId, ownerId });
+    }
+  }
+
+  async function processChunk(payload) {
+    const translationId = payload?.translationId;
+    const ownerId = payload?.ownerId || 'default';
+    const chunkOrder = payload?.chunkOrder;
+    if (!translationId || typeof chunkOrder === 'undefined') {
+      console.warn('processChunk invoked with invalid payload', { payload });
+      return;
+    }
+
+    let item;
+    try {
+      item = await getTranslationItem(translationId, ownerId);
+    } catch (err) {
+      console.error('processChunk missing translation item', { translationId, ownerId, error: err.message });
+      return;
+    }
+
+    const chunk = await getChunk(translationId, ownerId, chunkOrder);
+    if (!chunk) {
+      console.warn('processChunk could not find chunk', { translationId, ownerId, chunkOrder });
+      return;
+    }
+
+    if (chunk.status === 'COMPLETED') {
+      const chunks = await listChunks(translationId, ownerId);
+      const summary = summariseChunks(chunks);
+      if (summary.total > 0 && summary.completed === summary.total) {
+        await sendQueueMessage({ action: 'assemble', translationId, ownerId });
+      }
+      return;
+    }
+
+    const attempt = Number(chunk.machineAttempts || 0) + 1;
+    await updateChunkState({
+      translationId,
+      ownerId,
+      chunkOrder,
+      patch: {
+        status: 'PROCESSING',
+        startedAt: chunk.startedAt || now(),
+        machineAttempts: attempt
+      }
+    });
+
+    await recordLog({
+      translationId,
+      ownerId,
+      category: 'chunk-processing',
+      stage: 'machine-translation',
+      eventType: 'chunk-processing-started',
+      status: 'PROCESSING',
+      message: `Chunk ${chunkOrder} machine translation started`,
+      chunkProgress: {
+        completed: 0,
+        failed: 0,
+        total: item.totalChunks || 0
+      }
+    });
+
+    let engine;
+    try {
+      engine = await getTranslationEngine();
+    } catch (engineErr) {
+      await failTranslation({
+        translationId,
+        ownerId,
+        errorMessage: 'Failed to initialise translation engine',
+        context: { error: engineErr.message },
+        fileName: item.originalFilename
+      });
+      return;
+    }
+
+    try {
+      const result = await engine.translateChunk({
+        id: chunk.chunkId,
+        chunkId: chunk.chunkId,
+        order: chunk.order,
+        sourceHtml: chunk.sourceHtml
+      }, {
+        sourceLanguage: item.sourceLanguage || 'auto',
+        targetLanguage: item.targetLanguage || 'en',
+        attempt: attempt - 1
+      });
+
+      const updated = await updateChunkState({
+        translationId,
+        ownerId,
+        chunkOrder,
+        patch: {
+          status: 'COMPLETED',
+          machineHtml: result.translatedHtml || chunk.sourceHtml,
+          provider: result.provider || engine.name,
+          model: result.model || engine.model,
+          lastUpdatedBy: 'machine',
+          lastUpdatedAt: now(),
+          completedAt: now(),
+          errorMessage: null
+        }
+      });
+
+      const chunks = await listChunks(translationId, ownerId);
+      const summary = summariseChunks(chunks);
+      await updateTranslationItem(translationId, ownerId, {
+        processedChunks: summary.completed,
+        failedChunks: summary.failed
+      });
+
+      await recordLog({
+        translationId,
+        ownerId,
+        category: 'chunk-processing',
+        stage: 'machine-translation',
+        eventType: 'chunk-processed',
+        status: 'PROCESSING',
+        message: `Chunk ${chunkOrder} machine-translated`,
+        metadata: {
+          provider: updated?.provider || engine.name,
+          model: updated?.model || engine.model,
+          chunkOrder
+        },
+        chunkProgress: {
+          completed: summary.completed,
+          failed: summary.failed,
+          total: summary.total
+        }
+      });
+
+      if (summary.total > 0 && summary.completed === summary.total) {
+        await sendQueueMessage({ action: 'assemble', translationId, ownerId });
+      }
+    } catch (translateErr) {
+      await updateChunkState({
+        translationId,
+        ownerId,
+        chunkOrder,
+        patch: {
+          status: 'FAILED',
+          errorMessage: translateErr.message,
+          lastUpdatedBy: 'machine',
+          lastUpdatedAt: now()
+        }
+      });
+
+      await recordLog({
+        translationId,
+        ownerId,
+        category: 'chunk-processing',
+        stage: 'machine-translation',
+        eventType: 'chunk-translation-failed',
+        status: 'FAILED',
+        message: `Chunk ${chunkOrder} translation failed: ${translateErr.message}`,
+        metadata: { chunkOrder },
+        failureReason: translateErr.message
+      });
+
+      await failTranslation({
+        translationId,
+        ownerId,
+        errorMessage: 'Chunk translation failed',
+        context: { chunkOrder, error: translateErr.message },
+        fileName: item.originalFilename
+      });
+    }
+  }
+
+  async function assemble(payload) {
+    const translationId = payload?.translationId;
+    const ownerId = payload?.ownerId || 'default';
+    if (!translationId) {
+      console.warn('assemble invoked without translationId', { payload });
+      return;
+    }
+
+    let item;
+    try {
+      item = await getTranslationItem(translationId, ownerId);
+    } catch (err) {
+      console.error('assemble missing translation item', { translationId, ownerId, error: err.message });
+      return;
+    }
+
+    if (item.status === 'READY_FOR_REVIEW') {
+      console.log('assemble skipping completed translation', { translationId, ownerId });
+      return;
+    }
+
+    const chunks = await listChunks(translationId, ownerId);
+    const summary = summariseChunks(chunks);
+    if (!summary.total || summary.completed !== summary.total) {
+      console.warn('assemble invoked before all chunks completed', { translationId, ownerId, summary });
+      return;
+    }
+
+    let context = { headHtml: '', assets: [], anchors: [] };
+    if (item.documentContextKey) {
+      try {
+        const stored = await readObject(RAW_BUCKET, item.documentContextKey);
+        context = safeJsonParse(stored.buffer) || context;
+      } catch (err) {
+        console.warn('assemble failed to read context', { translationId, ownerId, error: err.message });
+      }
+    }
+
+    const normalizedChunks = chunks
+      .slice()
+      .sort((a, b) => (a.order || 0) - (b.order || 0))
+      .map(chunk => ({
+        id: chunk.chunkId,
+        order: chunk.order,
+        blockId: chunk.blockId || chunk.chunkId,
+        assetAnchors: chunk.assetAnchors || [],
+        sourceHtml: chunk.sourceHtml,
+        sourceText: chunk.sourceText,
+        machineHtml: chunk.machineHtml,
+        reviewerHtml: chunk.reviewerHtml || null,
+        provider: chunk.provider || item.provider || null,
+        model: chunk.model || item.model || null,
+        lastUpdatedBy: chunk.lastUpdatedBy || 'machine',
+        lastUpdatedAt: chunk.lastUpdatedAt || chunk.updatedAt || now(),
+        reviewerName: chunk.reviewerName || null
+      }));
+
+    const chunkPayload = {
+      translationId,
+      generatedAt: now(),
+      sourceLanguage: item.sourceLanguage,
+      targetLanguage: item.targetLanguage,
+      provider: normalizedChunks[0]?.provider || item.provider || null,
+      model: normalizedChunks[0]?.model || item.model || null,
+      headHtml: context.headHtml || item.headHtml || '',
+      chunks: normalizedChunks,
+      assets: context.assets || [],
+      anchors: context.anchors || []
+    };
+
+    const chunkKey = `translations/chunks/${ownerId}/${translationId}.json`;
+    try {
+      await putObject(RAW_BUCKET, chunkKey, JSON.stringify(chunkPayload), 'application/json');
+      await recordLog({
+        translationId,
+        ownerId,
+        category: 'reassembly',
+        stage: 'chunk-persist',
+        eventType: 'chunk-payload-stored',
+        status: 'PROCESSING',
+        message: 'Chunk payload persisted to storage',
+        metadata: {
+          chunkKey,
+          chunkCount: chunkPayload.chunks.length
+        },
+        chunkProgress: {
+          completed: chunkPayload.chunks.length,
+          failed: 0,
+          total: chunkPayload.chunks.length
+        }
+      });
+    } catch (chunkErr) {
+      await failTranslation({
+        translationId,
+        ownerId,
+        errorMessage: 'Failed to persist translation chunks',
+        context: { chunkKey, error: chunkErr.message },
+        fileName: item.originalFilename
+      });
+      return;
+    }
+
+    const machineHtml = assembleHtmlDocument({
+      headHtml: context.headHtml || item.headHtml,
+      chunks: normalizedChunks,
+      assets: context.assets || [],
+      anchors: context.anchors || []
+    });
+
+    const machineKey = `translations/machine/${ownerId}/${translationId}.html`;
+    try {
+      await putObject(RAW_BUCKET, machineKey, machineHtml, 'text/html');
+      await recordLog({
+        translationId,
+        ownerId,
+        category: 'reassembly',
+        stage: 'machine-output',
+        eventType: 'machine-html-stored',
+        status: 'PROCESSING',
+        message: 'Machine translated HTML stored',
+        metadata: {
+          machineKey,
+          htmlLength: machineHtml.length
+        }
+      });
+    } catch (htmlErr) {
+      await failTranslation({
+        translationId,
+        ownerId,
+        errorMessage: 'Failed to persist machine translated HTML',
+        context: { machineKey, error: htmlErr.message },
+        fileName: item.originalFilename
+      });
+      return;
+    }
+
+    await updateTranslationItem(translationId, ownerId, {
+      status: 'READY_FOR_REVIEW',
+      chunkFileKey: chunkKey,
+      machineFileKey: machineKey,
+      totalChunks: normalizedChunks.length,
+      translatedAt: now(),
+      provider: chunkPayload.provider,
+      model: chunkPayload.model,
+      processedChunks: normalizedChunks.length,
+      failedChunks: 0,
+      assetCount: (context.assets || []).length,
+      healthCheckRetries: 0,
+      healthCheckReason: null
+    });
+
+    await recordLog({
+      translationId,
+      ownerId,
+      category: 'processing',
+      stage: 'complete',
+      eventType: 'processing-completed',
+      status: 'READY_FOR_REVIEW',
+      message: 'Translation processing completed',
+      metadata: {
+        chunkFileKey: chunkKey,
+        machineFileKey: machineKey,
+        chunkCount: normalizedChunks.length,
+        assetCount: (context.assets || []).length,
+        provider: chunkPayload.provider,
+        model: chunkPayload.model
+      },
+      chunkProgress: {
+        completed: normalizedChunks.length,
+        failed: 0,
+        total: normalizedChunks.length
+      }
+    });
+
+    await sendJobNotification({
+      jobType: 'translation',
+      status: 'completed',
+      fileName: item.originalFilename,
+      jobId: translationId,
+      ownerId
+    });
+  }
+
+  return {
+    start: orchestrate,
+    orchestrate,
+    'process-chunk': processChunk,
+    process: processChunk,
+    assemble
+  };
+}
+
+module.exports = { createModeHandlers };

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -11,6 +11,7 @@
         "@aws-sdk/client-dynamodb": "^3.649.0",
         "@aws-sdk/client-s3": "^3.649.0",
         "@aws-sdk/client-s3vectors": "^3.649.0",
+        "@aws-sdk/client-sqs": "^3.899.0",
         "@aws-sdk/client-ssm": "^3.649.0",
         "@aws-sdk/s3-request-presigner": "^3.649.0",
         "@aws-sdk/util-dynamodb": "^3.649.0",
@@ -400,6 +401,495 @@
         "@smithy/util-middleware": "^4.0.5",
         "@smithy/util-retry": "^4.0.7",
         "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.899.0.tgz",
+      "integrity": "sha512-GCquRhawEup8jD5n4ItfMUxhlmly/QDZMsNU74olnJ9aEvL4OspmlBA89lQ6BJu/ctfPsnRCMtDQhhvagS7KyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.899.0",
+        "@aws-sdk/credential-provider-node": "3.899.0",
+        "@aws-sdk/middleware-host-header": "3.893.0",
+        "@aws-sdk/middleware-logger": "3.893.0",
+        "@aws-sdk/middleware-recursion-detection": "3.893.0",
+        "@aws-sdk/middleware-sdk-sqs": "3.899.0",
+        "@aws-sdk/middleware-user-agent": "3.899.0",
+        "@aws-sdk/region-config-resolver": "3.893.0",
+        "@aws-sdk/types": "3.893.0",
+        "@aws-sdk/util-endpoints": "3.895.0",
+        "@aws-sdk/util-user-agent-browser": "3.893.0",
+        "@aws-sdk/util-user-agent-node": "3.899.0",
+        "@smithy/config-resolver": "^4.2.2",
+        "@smithy/core": "^3.13.0",
+        "@smithy/fetch-http-handler": "^5.2.1",
+        "@smithy/hash-node": "^4.1.1",
+        "@smithy/invalid-dependency": "^4.1.1",
+        "@smithy/md5-js": "^4.1.1",
+        "@smithy/middleware-content-length": "^4.1.1",
+        "@smithy/middleware-endpoint": "^4.2.5",
+        "@smithy/middleware-retry": "^4.3.1",
+        "@smithy/middleware-serde": "^4.1.1",
+        "@smithy/middleware-stack": "^4.1.1",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/node-http-handler": "^4.2.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.5",
+        "@smithy/types": "^4.5.0",
+        "@smithy/url-parser": "^4.1.1",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-body-length-browser": "^4.1.0",
+        "@smithy/util-body-length-node": "^4.1.0",
+        "@smithy/util-defaults-mode-browser": "^4.1.5",
+        "@smithy/util-defaults-mode-node": "^4.1.5",
+        "@smithy/util-endpoints": "^3.1.2",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-retry": "^4.1.2",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/client-sso": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.899.0.tgz",
+      "integrity": "sha512-EKz/iiVDv2OC8/3ONcXG3+rhphx9Heh7KXQdsZzsAXGVn6mWtrHQLrWjgONckmK4LrD07y4+5WlJlGkMxSMA5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.899.0",
+        "@aws-sdk/middleware-host-header": "3.893.0",
+        "@aws-sdk/middleware-logger": "3.893.0",
+        "@aws-sdk/middleware-recursion-detection": "3.893.0",
+        "@aws-sdk/middleware-user-agent": "3.899.0",
+        "@aws-sdk/region-config-resolver": "3.893.0",
+        "@aws-sdk/types": "3.893.0",
+        "@aws-sdk/util-endpoints": "3.895.0",
+        "@aws-sdk/util-user-agent-browser": "3.893.0",
+        "@aws-sdk/util-user-agent-node": "3.899.0",
+        "@smithy/config-resolver": "^4.2.2",
+        "@smithy/core": "^3.13.0",
+        "@smithy/fetch-http-handler": "^5.2.1",
+        "@smithy/hash-node": "^4.1.1",
+        "@smithy/invalid-dependency": "^4.1.1",
+        "@smithy/middleware-content-length": "^4.1.1",
+        "@smithy/middleware-endpoint": "^4.2.5",
+        "@smithy/middleware-retry": "^4.3.1",
+        "@smithy/middleware-serde": "^4.1.1",
+        "@smithy/middleware-stack": "^4.1.1",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/node-http-handler": "^4.2.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.5",
+        "@smithy/types": "^4.5.0",
+        "@smithy/url-parser": "^4.1.1",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-body-length-browser": "^4.1.0",
+        "@smithy/util-body-length-node": "^4.1.0",
+        "@smithy/util-defaults-mode-browser": "^4.1.5",
+        "@smithy/util-defaults-mode-node": "^4.1.5",
+        "@smithy/util-endpoints": "^3.1.2",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-retry": "^4.1.2",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/core": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.899.0.tgz",
+      "integrity": "sha512-Enp5Zw37xaRlnscyaelaUZNxVqyE3CTS8gjahFbW2bbzVtRD2itHBVgq8A3lvKiFb7Feoxa71aTe0fQ1I6AhQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@aws-sdk/xml-builder": "3.894.0",
+        "@smithy/core": "^3.13.0",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/signature-v4": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.5",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.899.0.tgz",
+      "integrity": "sha512-wXQ//KQ751EFhUbdfoL/e2ZDaM8l2Cff+hVwFcj32yiZyeCMhnoLRMQk2euAaUOugqPY5V5qesFbHhISbIedtw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.899.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.899.0.tgz",
+      "integrity": "sha512-/rRHyJFdnPrupjt/1q/PxaO6O26HFsguVUJSUeMeGUWLy0W8OC3slLFDNh89CgTqnplCyt1aLFMCagRM20HjNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.899.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/fetch-http-handler": "^5.2.1",
+        "@smithy/node-http-handler": "^4.2.1",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.5",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-stream": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.899.0.tgz",
+      "integrity": "sha512-B8oFNFTDV0j1yiJiqzkC2ybml+theNnmsLrTLBhJbnBLWkxEcmVGKVIMnATW9BUCBhHmEtDiogdNIzSwP8tbMw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.899.0",
+        "@aws-sdk/credential-provider-env": "3.899.0",
+        "@aws-sdk/credential-provider-http": "3.899.0",
+        "@aws-sdk/credential-provider-process": "3.899.0",
+        "@aws-sdk/credential-provider-sso": "3.899.0",
+        "@aws-sdk/credential-provider-web-identity": "3.899.0",
+        "@aws-sdk/nested-clients": "3.899.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/credential-provider-imds": "^4.1.2",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.899.0.tgz",
+      "integrity": "sha512-nHBnZ2ZCOqTGJ2A9xpVj8iK6+WV+j0JNv3XGEkIuL4mqtGEPJlEex/0mD/hqc1VF8wZzojji2OQ3892m1mUOSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.899.0",
+        "@aws-sdk/credential-provider-http": "3.899.0",
+        "@aws-sdk/credential-provider-ini": "3.899.0",
+        "@aws-sdk/credential-provider-process": "3.899.0",
+        "@aws-sdk/credential-provider-sso": "3.899.0",
+        "@aws-sdk/credential-provider-web-identity": "3.899.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/credential-provider-imds": "^4.1.2",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.899.0.tgz",
+      "integrity": "sha512-1PWSejKcJQUKBNPIqSHlEW4w8vSjmb+3kNJqCinJybjp5uP5BJgBp6QNcb8Nv30VBM0bn3ajVd76LCq4ZshQAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.899.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.899.0.tgz",
+      "integrity": "sha512-URlMbo74CAhIGrhzEP2fw5F5Tt6MRUctA8aa88MomlEHCEbJDsMD3nh6qoXxwR3LyvEBFmCWOZ/1TWmAjMsSdA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.899.0",
+        "@aws-sdk/core": "3.899.0",
+        "@aws-sdk/token-providers": "3.899.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.899.0.tgz",
+      "integrity": "sha512-UEn5o5FMcbeFPRRkJI6VCrgdyR9qsLlGA7+AKCYuYADsKbvJGIIQk6A2oD82vIVvLYD3TtbTLDLsF7haF9mpbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.899.0",
+        "@aws-sdk/nested-clients": "3.899.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.893.0.tgz",
+      "integrity": "sha512-qL5xYRt80ahDfj9nDYLhpCNkDinEXvjLe/Qen/Y/u12+djrR2MB4DRa6mzBCkLkdXDtf0WAoW2EZsNCfGrmOEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.893.0.tgz",
+      "integrity": "sha512-ZqzMecjju5zkBquSIfVfCORI/3Mge21nUY4nWaGQy+NUXehqCGG4W7AiVpiHGOcY2cGJa7xeEkYcr2E2U9U0AA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.893.0.tgz",
+      "integrity": "sha512-H7Zotd9zUHQAr/wr3bcWHULYhEeoQrF54artgsoUGIf/9emv6LzY89QUccKIxYd6oHKNTrTyXm9F0ZZrzXNxlg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@aws/lambda-invoke-store": "^0.0.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.899.0.tgz",
+      "integrity": "sha512-6EsVCC9j1VIyVyLOg+HyO3z9L+c0PEwMiHe3kuocoMf8nkfjSzJfIl6zAtgAXWgP5MKvusTP2SUbS9ezEEHZ+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.899.0",
+        "@aws-sdk/types": "3.893.0",
+        "@aws-sdk/util-endpoints": "3.895.0",
+        "@smithy/core": "^3.13.0",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.899.0.tgz",
+      "integrity": "sha512-ySXXsFO0RH28VISEqvCuPZ78VAkK45/+OCIJgPvYpcCX9CVs70XSvMPXDI46I49mudJ1s4H3IUKccYSEtA+jaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.899.0",
+        "@aws-sdk/middleware-host-header": "3.893.0",
+        "@aws-sdk/middleware-logger": "3.893.0",
+        "@aws-sdk/middleware-recursion-detection": "3.893.0",
+        "@aws-sdk/middleware-user-agent": "3.899.0",
+        "@aws-sdk/region-config-resolver": "3.893.0",
+        "@aws-sdk/types": "3.893.0",
+        "@aws-sdk/util-endpoints": "3.895.0",
+        "@aws-sdk/util-user-agent-browser": "3.893.0",
+        "@aws-sdk/util-user-agent-node": "3.899.0",
+        "@smithy/config-resolver": "^4.2.2",
+        "@smithy/core": "^3.13.0",
+        "@smithy/fetch-http-handler": "^5.2.1",
+        "@smithy/hash-node": "^4.1.1",
+        "@smithy/invalid-dependency": "^4.1.1",
+        "@smithy/middleware-content-length": "^4.1.1",
+        "@smithy/middleware-endpoint": "^4.2.5",
+        "@smithy/middleware-retry": "^4.3.1",
+        "@smithy/middleware-serde": "^4.1.1",
+        "@smithy/middleware-stack": "^4.1.1",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/node-http-handler": "^4.2.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.5",
+        "@smithy/types": "^4.5.0",
+        "@smithy/url-parser": "^4.1.1",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-body-length-browser": "^4.1.0",
+        "@smithy/util-body-length-node": "^4.1.0",
+        "@smithy/util-defaults-mode-browser": "^4.1.5",
+        "@smithy/util-defaults-mode-node": "^4.1.5",
+        "@smithy/util-endpoints": "^3.1.2",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-retry": "^4.1.2",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.893.0.tgz",
+      "integrity": "sha512-/cJvh3Zsa+Of0Zbg7vl9wp/kZtdb40yk/2+XcroAMVPO9hPvmS9r/UOm6tO7FeX4TtkRFwWaQJiTZTgSdsPY+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-config-provider": "^4.1.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/token-providers": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.899.0.tgz",
+      "integrity": "sha512-Ovu1nWr8HafYa/7DaUvvPnzM/yDUGDBqaiS7rRzv++F5VwyFY37+z/mHhvRnr+PbNWo8uf22a121SNue5uwP2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.899.0",
+        "@aws-sdk/nested-clients": "3.899.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/types": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.893.0.tgz",
+      "integrity": "sha512-Aht1nn5SnA0N+Tjv0dzhAY7CQbxVtmq1bBR6xI0MhG7p2XYVh1wXuKTzrldEvQWwA3odOYunAfT9aBiKZx9qIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.895.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.895.0.tgz",
+      "integrity": "sha512-MhxBvWbwxmKknuggO2NeMwOVkHOYL98pZ+1ZRI5YwckoCL3AvISMnPJgfN60ww6AIXHGpkp+HhpFdKOe8RHSEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/types": "^4.5.0",
+        "@smithy/url-parser": "^4.1.1",
+        "@smithy/util-endpoints": "^3.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.893.0.tgz",
+      "integrity": "sha512-PE9NtbDBW6Kgl1bG6A5fF3EPo168tnkj8TgMcT0sg4xYBWsBpq0bpJZRh+Jm5Bkwiw9IgTCLjEU7mR6xWaMB9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/types": "^4.5.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.899.0.tgz",
+      "integrity": "sha512-CiP0UAVQWLg2+8yciUBzVLaK5Fr7jBQ7wVu+p/O2+nlCOD3E3vtL1KZ1qX/d3OVpVSVaMAdZ9nbyewGV9hvjjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.899.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.894.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.894.0.tgz",
+      "integrity": "sha512-E6EAMc9dT1a2DOdo4zyOf3fp5+NJ2wI+mcm7RaW1baFIWDwcb99PpvWoV7YEiK7oaBDshuOEGWKUSYXdW+JYgA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "fast-xml-parser": "5.2.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1162,6 +1652,36 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-sdk-sqs": {
+      "version": "3.899.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.899.0.tgz",
+      "integrity": "sha512-XjWdP6ZZWShkz8M+kUSydegxzEC0mA3Zswve+TjlSGOvFIEJ8DJzAxUZevIJUOUDYIoBa5ujQ4CRJDTmB5fAIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/smithy-client": "^4.6.5",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-hex-encoding": "^4.1.0",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sqs/node_modules/@aws-sdk/types": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.893.0.tgz",
+      "integrity": "sha512-Aht1nn5SnA0N+Tjv0dzhAY7CQbxVtmq1bBR6xI0MhG7p2XYVh1wXuKTzrldEvQWwA3odOYunAfT9aBiKZx9qIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-ssec": {
       "version": "3.873.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.873.0.tgz",
@@ -1446,6 +1966,15 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.0.1.tgz",
+      "integrity": "sha512-ORHRQ2tmvnBXc8t/X9Z8IcSbBA4xTLKuN873FopzklHMeqBst7YG0d+AX97inkvDX+NChYtSr+qGfcqGFaI8Zw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
@@ -1622,12 +2151,12 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.1.0.tgz",
-      "integrity": "sha512-wEhSYznxOmx7EdwK1tYEWJF5+/wmSFsff9BfTOn8oO/+KPl3gsmThrb6MJlWbOC391+Ya31s5JuHiC2RlT80Zg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.1.1.tgz",
+      "integrity": "sha512-vkzula+IwRvPR6oKQhMYioM3A/oX/lFCZiwuxkQbRhqJS2S4YRY2k7k/SyR2jMf3607HLtbEwlRxi0ndXHMjRg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.4.0",
+        "@smithy/types": "^4.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1660,15 +2189,15 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.2.0.tgz",
-      "integrity": "sha512-FA10YhPFLy23uxeWu7pOM2ctlw+gzbPMTZQwrZ8FRIfyJ/p8YIVz7AVTB5jjLD+QIerydyKcVMZur8qzzDILAQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.2.2.tgz",
+      "integrity": "sha512-IT6MatgBWagLybZl1xQcURXRICvqz1z3APSCAI9IqdvfCkrA7RaQIEfgC6G/KvfxnDfQUDqFV+ZlixcuFznGBQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.2.0",
-        "@smithy/types": "^4.4.0",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/types": "^4.5.0",
         "@smithy/util-config-provider": "^4.1.0",
-        "@smithy/util-middleware": "^4.1.0",
+        "@smithy/util-middleware": "^4.1.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1676,37 +2205,36 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.10.0.tgz",
-      "integrity": "sha512-bXyD3Ij6b1qDymEYlEcF+QIjwb9gObwZNaRjETJsUEvSIzxFdynSQ3E4ysY7lUFSBzeWBNaFvX+5A0smbC2q6A==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.13.0.tgz",
+      "integrity": "sha512-BI6ALLPOKnPOU1Cjkc+1TPhOlP3JXSR/UH14JmnaLq41t3ma+IjuXrKfhycVjr5IQ0XxRh2NnQo3olp+eCVrGg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.1.0",
-        "@smithy/protocol-http": "^5.2.0",
-        "@smithy/types": "^4.4.0",
+        "@smithy/middleware-serde": "^4.1.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
         "@smithy/util-base64": "^4.1.0",
         "@smithy/util-body-length-browser": "^4.1.0",
-        "@smithy/util-middleware": "^4.1.0",
-        "@smithy/util-stream": "^4.3.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-stream": "^4.3.2",
         "@smithy/util-utf8": "^4.1.0",
-        "@types/uuid": "^9.0.1",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
+        "@smithy/uuid": "^1.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.1.0.tgz",
-      "integrity": "sha512-iVwNhxTsCQTPdp++4C/d9xvaDmuEWhXi55qJobMp9QMaEHRGH3kErU4F8gohtdsawRqnUy/ANylCjKuhcR2mPw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.1.2.tgz",
+      "integrity": "sha512-JlYNq8TShnqCLg0h+afqe2wLAwZpuoSgOyzhYvTgbiKBWRov+uUve+vrZEQO6lkdLOWPh7gK5dtb9dS+KGendg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.2.0",
-        "@smithy/property-provider": "^4.1.0",
-        "@smithy/types": "^4.4.0",
-        "@smithy/url-parser": "^4.1.0",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/url-parser": "^4.1.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1784,14 +2312,14 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.2.0.tgz",
-      "integrity": "sha512-VZenjDdVaUGiy3hwQtxm75nhXZrhFG+3xyL93qCQAlYDyhT/jeDWM8/3r5uCFMlTmmyrIjiDyiOynVFchb0BSg==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.2.1.tgz",
+      "integrity": "sha512-5/3wxKNtV3wO/hk1is+CZUhL8a1yy/U+9u9LKQ9kZTkMsHaQjJhc3stFfiujtMnkITjzWfndGA2f7g9Uh9vKng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.2.0",
-        "@smithy/querystring-builder": "^4.1.0",
-        "@smithy/types": "^4.4.0",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/querystring-builder": "^4.1.1",
+        "@smithy/types": "^4.5.0",
         "@smithy/util-base64": "^4.1.0",
         "tslib": "^2.6.2"
       },
@@ -1815,12 +2343,12 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.1.0.tgz",
-      "integrity": "sha512-mXkJQ/6lAXTuoSsEH+d/fHa4ms4qV5LqYoPLYhmhCRTNcMMdg+4Ya8cMgU1W8+OR40eX0kzsExT7fAILqtTl2w==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.1.1.tgz",
+      "integrity": "sha512-H9DIU9WBLhYrvPs9v4sYvnZ1PiAI0oc8CgNQUJ1rpN3pP7QADbTOUjchI2FB764Ub0DstH5xbTqcMJu1pnVqxA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.4.0",
+        "@smithy/types": "^4.5.0",
         "@smithy/util-buffer-from": "^4.1.0",
         "@smithy/util-utf8": "^4.1.0",
         "tslib": "^2.6.2"
@@ -1844,12 +2372,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.1.0.tgz",
-      "integrity": "sha512-4/FcV6aCMzgpM4YyA/GRzTtG28G0RQJcWK722MmpIgzOyfSceWcI9T9c8matpHU9qYYLaWtk8pSGNCLn5kzDRw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.1.1.tgz",
+      "integrity": "sha512-1AqLyFlfrrDkyES8uhINRlJXmHA2FkG+3DY8X+rmLSqmFwk3DJnvhyGzyByPyewh2jbmV+TYQBEfngQax8IFGg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.4.0",
+        "@smithy/types": "^4.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1869,12 +2397,12 @@
       }
     },
     "node_modules/@smithy/md5-js": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.1.0.tgz",
-      "integrity": "sha512-RW1+/E3rv80254ekFqiUTM8ExtN0dG9dkUwU2x17rxS4Mn2ib3SrTCdayCiNbfj6xWHupzgOJB6iNoXiOzNe6g==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.1.1.tgz",
+      "integrity": "sha512-MvWXKK743BuHjr/hnWuT6uStdKEaoqxHAQUvbKJPPZM5ZojTNFI5D+47BoQfBE5RgGlRRty05EbWA+NXDv+hIA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.4.0",
+        "@smithy/types": "^4.5.0",
         "@smithy/util-utf8": "^4.1.0",
         "tslib": "^2.6.2"
       },
@@ -1883,13 +2411,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.1.0.tgz",
-      "integrity": "sha512-x3dgLFubk/ClKVniJu+ELeZGk4mq7Iv0HgCRUlxNUIcerHTLVmq7Q5eGJL0tOnUltY6KFw5YOKaYxwdcMwox/w==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.1.1.tgz",
+      "integrity": "sha512-9wlfBBgTsRvC2JxLJxv4xDGNBrZuio3AgSl0lSFX7fneW2cGskXTYpFxCdRYD2+5yzmsiTuaAJD1Wp7gWt9y9w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.2.0",
-        "@smithy/types": "^4.4.0",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1897,18 +2425,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.2.0.tgz",
-      "integrity": "sha512-J1eCF7pPDwgv7fGwRd2+Y+H9hlIolF3OZ2PjptonzzyOXXGh/1KGJAHpEcY1EX+WLlclKu2yC5k+9jWXdUG4YQ==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.2.5.tgz",
+      "integrity": "sha512-DdOIpssQ5LFev7hV6GX9TMBW5ChTsQBxqgNW1ZGtJNSAi5ksd5klwPwwMY0ejejfEzwXXGqxgVO3cpaod4veiA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.10.0",
-        "@smithy/middleware-serde": "^4.1.0",
-        "@smithy/node-config-provider": "^4.2.0",
-        "@smithy/shared-ini-file-loader": "^4.1.0",
-        "@smithy/types": "^4.4.0",
-        "@smithy/url-parser": "^4.1.0",
-        "@smithy/util-middleware": "^4.1.0",
+        "@smithy/core": "^3.13.0",
+        "@smithy/middleware-serde": "^4.1.1",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "@smithy/url-parser": "^4.1.1",
+        "@smithy/util-middleware": "^4.1.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1916,34 +2444,33 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.2.0.tgz",
-      "integrity": "sha512-raL5oWYf5ALl3jCJrajE8enKJEnV/2wZkKS6mb3ZRY2tg3nj66ssdWy5Ps8E6Yu8Wqh3Tt+Sb9LozjvwZupq+A==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.3.1.tgz",
+      "integrity": "sha512-aH2bD1bzb6FB04XBhXA5mgedEZPKx3tD/qBuYCAKt5iieWvWO1Y2j++J9uLqOndXb9Pf/83Xka/YjSnMbcPchA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.2.0",
-        "@smithy/protocol-http": "^5.2.0",
-        "@smithy/service-error-classification": "^4.1.0",
-        "@smithy/smithy-client": "^4.6.0",
-        "@smithy/types": "^4.4.0",
-        "@smithy/util-middleware": "^4.1.0",
-        "@smithy/util-retry": "^4.1.0",
-        "@types/uuid": "^9.0.1",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/service-error-classification": "^4.1.2",
+        "@smithy/smithy-client": "^4.6.5",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-retry": "^4.1.2",
+        "@smithy/uuid": "^1.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.1.0.tgz",
-      "integrity": "sha512-CtLFYlHt7c2VcztyVRc+25JLV4aGpmaSv9F1sPB0AGFL6S+RPythkqpGDa2XBQLJQooKkjLA1g7Xe4450knShg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.1.1.tgz",
+      "integrity": "sha512-lh48uQdbCoj619kRouev5XbWhCwRKLmphAif16c4J6JgJ4uXjub1PI6RL38d3BLliUvSso6klyB/LTNpWSNIyg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.2.0",
-        "@smithy/types": "^4.4.0",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1951,12 +2478,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.1.0.tgz",
-      "integrity": "sha512-91Fuw4IKp0eK8PNhMXrHRcYA1jvbZ9BJGT91wwPy3bTQT8mHTcQNius/EhSQTlT9QUI3Ki1wjHeNXbWK0tO8YQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.1.1.tgz",
+      "integrity": "sha512-ygRnniqNcDhHzs6QAPIdia26M7e7z9gpkIMUe/pK0RsrQ7i5MblwxY8078/QCnGq6AmlUUWgljK2HlelsKIb/A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.4.0",
+        "@smithy/types": "^4.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1964,14 +2491,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.2.0.tgz",
-      "integrity": "sha512-8/fpilqKurQ+f8nFvoFkJ0lrymoMJ+5/CQV5IcTv/MyKhk2Q/EFYCAgTSWHD4nMi9ux9NyBBynkyE9SLg2uSLA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.2.2.tgz",
+      "integrity": "sha512-SYGTKyPvyCfEzIN5rD8q/bYaOPZprYUPD2f5g9M7OjaYupWOoQFYJ5ho+0wvxIRf471i2SR4GoiZ2r94Jq9h6A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.1.0",
-        "@smithy/shared-ini-file-loader": "^4.1.0",
-        "@smithy/types": "^4.4.0",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1979,15 +2506,15 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.2.0.tgz",
-      "integrity": "sha512-G4NV70B4hF9vBrUkkvNfWO6+QR4jYjeO4tc+4XrKCb4nPYj49V9Hu8Ftio7Mb0/0IlFyEOORudHrm+isY29nCA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.2.1.tgz",
+      "integrity": "sha512-REyybygHlxo3TJICPF89N2pMQSf+p+tBJqpVe1+77Cfi9HBPReNjTgtZ1Vg73exq24vkqJskKDpfF74reXjxfw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.1.0",
-        "@smithy/protocol-http": "^5.2.0",
-        "@smithy/querystring-builder": "^4.1.0",
-        "@smithy/types": "^4.4.0",
+        "@smithy/abort-controller": "^4.1.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/querystring-builder": "^4.1.1",
+        "@smithy/types": "^4.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1995,12 +2522,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.1.0.tgz",
-      "integrity": "sha512-eksMjMHUlG5PwOUWO3k+rfLNOPVPJ70mUzyYNKb5lvyIuAwS4zpWGsxGiuT74DFWonW0xRNy+jgzGauUzX7SyA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.1.1.tgz",
+      "integrity": "sha512-gm3ZS7DHxUbzC2wr8MUCsAabyiXY0gaj3ROWnhSx/9sPMc6eYLMM4rX81w1zsMaObj2Lq3PZtNCC1J6lpEY7zg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.4.0",
+        "@smithy/types": "^4.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2008,12 +2535,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.2.0.tgz",
-      "integrity": "sha512-bwjlh5JwdOQnA01be+5UvHK4HQz4iaRKlVG46hHSJuqi0Ribt3K06Z1oQ29i35Np4G9MCDgkOGcHVyLMreMcbg==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.2.1.tgz",
+      "integrity": "sha512-T8SlkLYCwfT/6m33SIU/JOVGNwoelkrvGjFKDSDtVvAXj/9gOT78JVJEas5a+ETjOu4SVvpCstKgd0PxSu/aHw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.4.0",
+        "@smithy/types": "^4.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2021,12 +2548,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.1.0.tgz",
-      "integrity": "sha512-JqTWmVIq4AF8R8OK/2cCCiQo5ZJ0SRPsDkDgLO5/3z8xxuUp1oMIBBjfuueEe+11hGTZ6rRebzYikpKc6yQV9Q==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.1.1.tgz",
+      "integrity": "sha512-J9b55bfimP4z/Jg1gNo+AT84hr90p716/nvxDkPGCD4W70MPms0h8KF50RDRgBGZeL83/u59DWNqJv6tEP/DHA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.4.0",
+        "@smithy/types": "^4.5.0",
         "@smithy/util-uri-escape": "^4.1.0",
         "tslib": "^2.6.2"
       },
@@ -2035,12 +2562,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.1.0.tgz",
-      "integrity": "sha512-VgdHhr8YTRsjOl4hnKFm7xEMOCRTnKw3FJ1nU+dlWNhdt/7eEtxtkdrJdx7PlRTabdANTmvyjE4umUl9cK4awg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.1.1.tgz",
+      "integrity": "sha512-63TEp92YFz0oQ7Pj9IuI3IgnprP92LrZtRAkE3c6wLWJxfy/yOPRt39IOKerVr0JS770olzl0kGafXlAXZ1vng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.4.0",
+        "@smithy/types": "^4.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2048,24 +2575,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.1.0.tgz",
-      "integrity": "sha512-UBpNFzBNmS20jJomuYn++Y+soF8rOK9AvIGjS9yGP6uRXF5rP18h4FDUsoNpWTlSsmiJ87e2DpZo9ywzSMH7PQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.1.2.tgz",
+      "integrity": "sha512-Kqd8wyfmBWHZNppZSMfrQFpc3M9Y/kjyN8n8P4DqJJtuwgK1H914R471HTw7+RL+T7+kI1f1gOnL7Vb5z9+NgQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.4.0"
+        "@smithy/types": "^4.5.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.1.0.tgz",
-      "integrity": "sha512-W0VMlz9yGdQ/0ZAgWICFjFHTVU0YSfGoCVpKaExRM/FDkTeP/yz8OKvjtGjs6oFokCRm0srgj/g4Cg0xuHu8Rw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.2.0.tgz",
+      "integrity": "sha512-OQTfmIEp2LLuWdxa8nEEPhZmiOREO6bcB6pjs0AySf4yiZhl6kMOfqmcwcY8BaBPX+0Tb+tG7/Ia/6mwpoZ7Pw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.4.0",
+        "@smithy/types": "^4.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2073,16 +2600,16 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.2.0.tgz",
-      "integrity": "sha512-ObX1ZqG2DdZQlXx9mLD7yAR8AGb7yXurGm+iWx9x4l1fBZ8CZN2BRT09aSbcXVPZXWGdn5VtMuupjxhOTI2EjA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.2.1.tgz",
+      "integrity": "sha512-M9rZhWQLjlQVCCR37cSjHfhriGRN+FQ8UfgrYNufv66TJgk+acaggShl3KS5U/ssxivvZLlnj7QH2CUOKlxPyA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.1.0",
-        "@smithy/protocol-http": "^5.2.0",
-        "@smithy/types": "^4.4.0",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
         "@smithy/util-hex-encoding": "^4.1.0",
-        "@smithy/util-middleware": "^4.1.0",
+        "@smithy/util-middleware": "^4.1.1",
         "@smithy/util-uri-escape": "^4.1.0",
         "@smithy/util-utf8": "^4.1.0",
         "tslib": "^2.6.2"
@@ -2092,17 +2619,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.6.0.tgz",
-      "integrity": "sha512-TvlIshqx5PIi0I0AiR+PluCpJ8olVG++xbYkAIGCUkByaMUlfOXLgjQTmYbr46k4wuDe8eHiTIlUflnjK2drPQ==",
+      "version": "4.6.5",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.6.5.tgz",
+      "integrity": "sha512-6J2hhuWu7EjnvLBIGltPCqzNswL1cW/AkaZx6i56qLsQ0ix17IAhmDD9aMmL+6CN9nCJODOXpBTCQS6iKAA7/g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.10.0",
-        "@smithy/middleware-endpoint": "^4.2.0",
-        "@smithy/middleware-stack": "^4.1.0",
-        "@smithy/protocol-http": "^5.2.0",
-        "@smithy/types": "^4.4.0",
-        "@smithy/util-stream": "^4.3.0",
+        "@smithy/core": "^3.13.0",
+        "@smithy/middleware-endpoint": "^4.2.5",
+        "@smithy/middleware-stack": "^4.1.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-stream": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2110,9 +2637,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.4.0.tgz",
-      "integrity": "sha512-4jY91NgZz+ZnSFcVzWwngOW6VuK3gR/ihTwSU1R/0NENe9Jd8SfWgbhDCAGUWL3bI7DiDSW7XF6Ui6bBBjrqXw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.5.0.tgz",
+      "integrity": "sha512-RkUpIOsVlAwUIZXO1dsz8Zm+N72LClFfsNqf173catVlvRZiwPy0x2u0JLEA4byreOPKDZPGjmPDylMoP8ZJRg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2122,13 +2649,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.1.0.tgz",
-      "integrity": "sha512-/LYEIOuO5B2u++tKr1NxNxhZTrr3A63jW8N73YTwVeUyAlbB/YM+hkftsvtKAcMt3ADYo0FsF1GY3anehffSVQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.1.1.tgz",
+      "integrity": "sha512-bx32FUpkhcaKlEoOMbScvc93isaSiRM75pQ5IgIBaMkT7qMlIibpPRONyx/0CvrXHzJLpOn/u6YiDX2hcvs7Dg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.1.0",
-        "@smithy/types": "^4.4.0",
+        "@smithy/querystring-parser": "^4.1.1",
+        "@smithy/types": "^4.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2199,14 +2726,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.1.0.tgz",
-      "integrity": "sha512-D27cLtJtC4EEeERJXS+JPoogz2tE5zeE3zhWSSu6ER5/wJ5gihUxIzoarDX6K1U27IFTHit5YfHqU4Y9RSGE0w==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.1.5.tgz",
+      "integrity": "sha512-FGBhlmFZVSRto816l6IwrmDcQ9pUYX6ikdR1mmAhdtSS1m77FgADukbQg7F7gurXfAvloxE/pgsrb7SGja6FQA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.1.0",
-        "@smithy/smithy-client": "^4.6.0",
-        "@smithy/types": "^4.4.0",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/smithy-client": "^4.6.5",
+        "@smithy/types": "^4.5.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -2215,17 +2742,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.1.0.tgz",
-      "integrity": "sha512-gnZo3u5dP1o87plKupg39alsbeIY1oFFnCyV2nI/++pL19vTtBLgOyftLEjPjuXmoKn2B2rskX8b7wtC/+3Okg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.1.5.tgz",
+      "integrity": "sha512-Gwj8KLgJ/+MHYjVubJF0EELEh9/Ir7z7DFqyYlwgmp4J37KE+5vz6b3pWUnSt53tIe5FjDfVjDmHGYKjwIvW0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.2.0",
-        "@smithy/credential-provider-imds": "^4.1.0",
-        "@smithy/node-config-provider": "^4.2.0",
-        "@smithy/property-provider": "^4.1.0",
-        "@smithy/smithy-client": "^4.6.0",
-        "@smithy/types": "^4.4.0",
+        "@smithy/config-resolver": "^4.2.2",
+        "@smithy/credential-provider-imds": "^4.1.2",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/smithy-client": "^4.6.5",
+        "@smithy/types": "^4.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2233,13 +2760,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.1.0.tgz",
-      "integrity": "sha512-5LFg48KkunBVGrNs3dnQgLlMXJLVo7k9sdZV5su3rjO3c3DmQ2LwUZI0Zr49p89JWK6sB7KmzyI2fVcDsZkwuw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.1.2.tgz",
+      "integrity": "sha512-+AJsaaEGb5ySvf1SKMRrPZdYHRYSzMkCoK16jWnIMpREAnflVspMIDeCVSZJuj+5muZfgGpNpijE3mUNtjv01Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.2.0",
-        "@smithy/types": "^4.4.0",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/types": "^4.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2259,12 +2786,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.1.0.tgz",
-      "integrity": "sha512-612onNcKyxhP7/YOTKFTb2F6sPYtMRddlT5mZvYf1zduzaGzkYhpYIPxIeeEwBZFjnvEqe53Ijl2cYEfJ9d6/Q==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.1.1.tgz",
+      "integrity": "sha512-CGmZ72mL29VMfESz7S6dekqzCh8ZISj3B+w0g1hZFXaOjGTVaSqfAEFAq8EGp8fUL+Q2l8aqNmt8U1tglTikeg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.4.0",
+        "@smithy/types": "^4.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2272,13 +2799,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.1.0.tgz",
-      "integrity": "sha512-5AGoBHb207xAKSVwaUnaER+L55WFY8o2RhlafELZR3mB0J91fpL+Qn+zgRkPzns3kccGaF2vy0HmNVBMWmN6dA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.1.2.tgz",
+      "integrity": "sha512-NCgr1d0/EdeP6U5PSZ9Uv5SMR5XRRYoVr1kRVtKZxWL3tixEL3UatrPIMFZSKwHlCcp2zPLDvMubVDULRqeunA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.1.0",
-        "@smithy/types": "^4.4.0",
+        "@smithy/service-error-classification": "^4.1.2",
+        "@smithy/types": "^4.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2286,14 +2813,14 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.3.0.tgz",
-      "integrity": "sha512-ZOYS94jksDwvsCJtppHprUhsIscRnCKGr6FXCo3SxgQ31ECbza3wqDBqSy6IsAak+h/oAXb1+UYEBmDdseAjUQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.3.2.tgz",
+      "integrity": "sha512-Ka+FA2UCC/Q1dEqUanCdpqwxOFdf5Dg2VXtPtB1qxLcSGh5C1HdzklIt18xL504Wiy9nNUKwDMRTVCbKGoK69g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.2.0",
-        "@smithy/node-http-handler": "^4.2.0",
-        "@smithy/types": "^4.4.0",
+        "@smithy/fetch-http-handler": "^5.2.1",
+        "@smithy/node-http-handler": "^4.2.1",
+        "@smithy/types": "^4.5.0",
         "@smithy/util-base64": "^4.1.0",
         "@smithy/util-buffer-from": "^4.1.0",
         "@smithy/util-hex-encoding": "^4.1.0",
@@ -2337,6 +2864,18 @@
       "dependencies": {
         "@smithy/abort-controller": "^4.1.0",
         "@smithy/types": "^4.4.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.0.0.tgz",
+      "integrity": "sha512-OlA/yZHh0ekYFnbUkmYBDQPE6fGfdrvgz39ktp8Xf+FA6BfxLejPTMDOG0Nfk5/rDySAz1dRbFf24zaAFYVXlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {

--- a/src/package.json
+++ b/src/package.json
@@ -11,6 +11,7 @@
     "@aws-sdk/client-dynamodb": "^3.649.0",
     "@aws-sdk/client-s3": "^3.649.0",
     "@aws-sdk/client-s3vectors": "^3.649.0",
+    "@aws-sdk/client-sqs": "^3.899.0",
     "@aws-sdk/client-ssm": "^3.649.0",
     "@aws-sdk/s3-request-presigner": "^3.649.0",
     "@aws-sdk/util-dynamodb": "^3.649.0",


### PR DESCRIPTION
## Summary
- add a dedicated SQS queue and wire the translation worker Lambda, API handler, and health check to publish and consume fan-out jobs
- refactor the translation worker into orchestrate, per-chunk processing, and assembly modes backed by a helper module and updated translation store utilities
- ensure translation requests and restarts enqueue work on SQS while the engine can translate individual chunks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db1e0b04888331bafc226af94fad03